### PR TITLE
(fix): checking `None` membership in `__getitem__`

### DIFF
--- a/src/finch/tensor.py
+++ b/src/finch/tensor.py
@@ -244,8 +244,9 @@ class Tensor(_Display, SparseArray):
     def __getitem__(self, key):
         if not isinstance(key, tuple):
             key = (key,)
-
-        if None in key:
+        # if key is a numpy array or similar, == does not provide a boolean
+        # see: https://docs.python.org/3/reference/expressions.html#membership-test-operations
+        if any(k is None for k in key):
             # lazy indexing mode
             key = _process_lazy_indexing(key)
         else:


### PR DESCRIPTION
I ran into this issue when trying to index ~with a tuple~ that had a numpy array in it:

```python
import finch
import numpy as np

tensor = finch.Tensor(np.array([[1, 2], [3, 4]]))
tensor[finch.Tensor(np.array([False, True]))]
```

Previously, `None in key` would trigger `None==k for k in key` (see the link in the comment) which is not really compatible with numpy arrays.  Maybe `key` shouldn't be a `numpy` array though but couldn't tell? Happy to update.

I don't see any indexing tests that have a numpy array in https://github.com/finch-tensor/finch-tensor-python/blob/main/tests/test_indexing.py though...but also array-api compat would say boolean indexes are good https://data-apis.org/array-api/latest/API_specification/indexing.html#boolean-array-indexing