### PR TITLE
Early Return Pipeline

### DIFF
--- a/benchmarks/test_galley.py
+++ b/benchmarks/test_galley.py
@@ -27,6 +27,7 @@ from finchlite.autoschedule.tensor_stats import UniformStatsFactory
 from finchlite.finch_logic import Alias, Field, Plan, Produces, Query, Table
 from finchlite.finch_notation.interpreter import NotationInterpreter
 from finchlite.symbolic import gensym
+from finchlite.symbolic.stage import NoOpStage
 
 from .utils import patch_benchmark
 
@@ -91,13 +92,22 @@ def _make_pipeline():
 def test_galley_matmul_chain(
     benchmark, monkeypatch, empty_last: bool, metric: Literal["optimize", "downstream"]
 ) -> None:
-    import finchlite.autoschedule.galley_optimize as galley
 
+    plan = _plan_from_lazy(_build_expr(empty_last))
     if metric == "optimize":
-        patch_benchmark(benchmark, monkeypatch, galley, "optimize_plan")
+        opt_only = LogicNormalizer(
+            LogicExecutor(
+                GalleyLogicalOptimizer(
+                    DefaultLoopOrderer(
+                        LogicStandardizer(DefaultLogicFormatter(NoOpStage()))
+                    )
+                ),
+                no_compute=True,
+            )
+        )
+        benchmark(opt_only, plan)
     else:
         patch_benchmark(benchmark, monkeypatch, LogicStandardizer, "lower")
 
     pipeline = _make_pipeline()
-    plan = _plan_from_lazy(_build_expr(empty_last))
     pipeline(plan)

--- a/src/finchlite/autoschedule/executor.py
+++ b/src/finchlite/autoschedule/executor.py
@@ -50,6 +50,7 @@ class LogicExecutor(UnvalidatedForm, LogicEvaluator):
         ctx: LogicLoader | None = None,
         stats_factory: StatsFactory | None = None,
         cache: bool = False,
+        no_compute: bool = False,
     ):
         if ctx is None:
             ctx = DefaultLogicFormatter()
@@ -59,6 +60,7 @@ class LogicExecutor(UnvalidatedForm, LogicEvaluator):
         self.stats_factory = stats_factory
         self.cache = cache
         self.cached_kernels: dict[tuple[Any, Any], Any] = {}
+        self.no_compute = no_compute
 
     def lower(
         self,
@@ -96,13 +98,17 @@ class LogicExecutor(UnvalidatedForm, LogicEvaluator):
                 fields = tuple(lgc.Field(f"d{i}") for i in range(len(shape)))
                 stats_bindings[var] = self.stats_factory(T, fields)
 
-            mod, binding_ftypes, binding_idxs = self.ctx(
+            outputs = self.ctx(
                 stmt,
                 binding_ftypes,
                 stats_bindings,
                 self.stats_factory,
             )
 
+            if self.no_compute:
+                return outputs
+
+            mod, binding_ftypes, binding_idxs = outputs
             if self.cache:
                 self.cached_kernels[key] = mod, binding_ftypes, binding_idxs
 

--- a/src/finchlite/symbolic/__init__.py
+++ b/src/finchlite/symbolic/__init__.py
@@ -9,7 +9,7 @@ from .rewriters import (
     PreWalk,
     Rewrite,
 )
-from .stage import Form, Stage, UnvalidatedForm
+from .stage import Form, NoOpStage, Stage, UnvalidatedForm
 from .term import (
     Term,
     TermTree,
@@ -28,6 +28,7 @@ __all__ = [
     "Memo",
     "NamedTerm",
     "Namespace",
+    "NoOpStage",
     "PostOrderDFS",
     "PostWalk",
     "PreOrderDFS",

--- a/src/finchlite/symbolic/stage.py
+++ b/src/finchlite/symbolic/stage.py
@@ -34,3 +34,8 @@ class UnvalidatedForm(Form):
     @classmethod
     def validate_inputs(cls, *inputs):
         return
+
+
+class NoOpStage(UnvalidatedForm, Stage):
+    def lower(self, *inputs):
+        return inputs


### PR DESCRIPTION
This PR adds:

1) a no_compute option to LogicExecutor where it returns whatever its interior ctx produces
2) a NoOp stage which immediately returns its inputs

An early return pipeline can then look like, e.g. :
```
LogicNormalizer(
            LogicExecutor( GalleyLogicalOptimizer(DefaultLoopOrderer(NoOpStage()
                    )
                )

```