### PR TITLE
Annotated Query Paths + Literals Fix

### DIFF
--- a/src/finch/autoschedule/compiler.py
+++ b/src/finch/autoschedule/compiler.py
@@ -54,6 +54,8 @@ class PointwiseContext:
                         tuple(loops[idx] for idx in idxs),
                     )
                 )
+            case lgc.Literal(val):
+                return ntn.Literal(val)
             case lgc.Relabel(arg, idxs):
                 return self(
                     arg,

--- a/src/finch/autoschedule/galley/logical_optimizer/annotated_query.py
+++ b/src/finch/autoschedule/galley/logical_optimizer/annotated_query.py
@@ -29,6 +29,7 @@ from finch.finch_logic import (
     TensorStats,
 )
 from finch.symbolic import gensym
+from finch.tensor import Scalar
 
 from .logic_to_stats import insert_statistics
 
@@ -111,8 +112,7 @@ class AnnotatedQuery:
         ) -> tuple[LogicNode, list[tuple[Field, Path, Literal, Literal, LogicNode]]]:
             """Remove Aggregate nodes bottom-up, recording each reduction index
             together with the path of the aggregate's argument in the stripped
-            tree. An aggregate collapses to its argument, so that path is the
-            aggregate's own position."""
+            tree."""
             match node:
                 case Aggregate(Literal() as op, Literal() as init, arg, idxs):
                     new_arg, records = strip_aggregates(arg)
@@ -166,11 +166,10 @@ class AnnotatedQuery:
             (idx, idx) for idx in cache[q.rhs].index_order
         )
         idx_lowest_path: OrderedDict[Field, Path] = OrderedDict()
-        repeats: dict[Path, OrderedDict[Field, tuple[FinchOperator, Any]]] = {}
         stats_point = cache_point[point_expr]
+        self.idx_dim_size: dict[Field, Any] = dict(stats_point.dim_sizes)
         for idx in starting_reduce_idxs:
             agg_op = idx_op[idx]
-            idx_dim_size = stats_point.dim_sizes[idx]
             starting_path = idx_starting_path[idx]
             lowest_paths = AnnotatedQuery.find_lowest_roots(
                 agg_op,
@@ -191,19 +190,6 @@ class AnnotatedQuery:
                     for i, _ in enumerate(lowest_paths, start=1)
                 ]
                 for i, path in enumerate(lowest_paths):
-                    node = AnnotatedQuery.node_at(point_expr, path)
-                    if idx not in cache_point[node].index_order:
-                        # If the lowest root doesn't contain the reduction index, we
-                        # attempt to remove the reduction via a repeat_operator, i.e.
-                        # ∑_i B_j = B_j*|Dom(i)|
-                        f = repeat_operator(agg_op)
-                        if f is None:
-                            continue
-                        repeats.setdefault(path, OrderedDict())[idx] = (
-                            f,
-                            idx_dim_size,
-                        )
-                        continue
                     new_idx = new_idxs[i]
                     idx_op[new_idx] = agg_op
                     idx_init[new_idx] = idx_init[idx]
@@ -211,65 +197,6 @@ class AnnotatedQuery:
                     idx_starting_path[new_idx] = starting_path
                     original_idx[new_idx] = idx
                     reduce_idxs.append(new_idx)
-
-        if repeats:
-            # Repeats over several indices with the same operator compose by
-            # multiplying their domain sizes, since the repeat operators are
-            # power-like: (x*d1)*d2 == x*(d1*d2) and (x**d1)**d2 == x**(d1*d2).
-            wrap_groups: dict[Path, list[tuple[FinchOperator, Any]]] = {}
-            for path, per_idx in repeats.items():
-                groups: list[tuple[FinchOperator, Any]] = []
-                for f, size in per_idx.values():
-                    if groups and groups[-1][0] == f:
-                        groups[-1] = (f, groups[-1][1] * size)
-                    else:
-                        groups.append((f, size))
-                wrap_groups[path] = groups
-
-            def make_wrap(
-                groups: list[tuple[FinchOperator, Any]],
-            ) -> Callable[[LogicNode], LogicNode]:
-                def wrap(node: LogicNode) -> LogicNode:
-                    for f, factor in groups:
-                        node = MapJoin(
-                            Literal(f),
-                            (cast(LogicExpression, node), Literal(factor)),
-                        )
-                    return node
-
-                return wrap
-
-            point_expr = cast(
-                LogicExpression,
-                AnnotatedQuery.replace_at(
-                    point_expr,
-                    {path: make_wrap(g) for path, g in wrap_groups.items()},
-                ),
-            )
-            # Wrapping inserts MapJoin levels above the wrapped nodes, so every
-            # stored path running through a wrapped position must be remapped.
-            # The wrapped node sits at child 1 of each inserted MapJoin
-            # (children are [op, node, factor]).
-            wrap_paths = sorted(wrap_groups, key=len, reverse=True)
-
-            def remap_through_wraps(path: Path) -> Path:
-                for p in wrap_paths:
-                    if path[: len(p)] == p:
-                        levels = (1,) * len(wrap_groups[p])
-                        path = (*p, *levels, *path[len(p) :])
-                return path
-
-            for idx, path in idx_lowest_path.items():
-                idx_lowest_path[idx] = remap_through_wraps(path)
-            for idx, path in idx_starting_path.items():
-                idx_starting_path[idx] = remap_through_wraps(path)
-            insert_statistics(
-                self.stats_factory,
-                point_expr,
-                bindings=bindings,
-                replace=False,
-                cache=cache_point,
-            )
 
         parent_idxs: OrderedDict[Field, list[Field]] = OrderedDict(
             (i, []) for i in reduce_idxs
@@ -345,6 +272,7 @@ class AnnotatedQuery:
         new.bindings = OrderedDict(self.bindings.items())
         new.cache = OrderedDict(self.cache.items())
         new.cache_point = OrderedDict(self.cache_point.items())
+        new.idx_dim_size = dict(self.idx_dim_size)
 
         return new
 
@@ -608,8 +536,6 @@ class AnnotatedQuery:
         """
         match root:
             case MapJoin(Literal(FinchOperator() as mj_op), args):
-                # A MapJoin's children are [op, *args]: argument i is child
-                # i + 1.
                 with_idx = [
                     (i, arg) for i, arg in enumerate(args) if idx in arg.fields()
                 ]
@@ -707,8 +633,6 @@ class AnnotatedQuery:
                 if len(relevant_pos) == len(args):
                     replace_path = root_path
                 else:
-                    # A MapJoin's children are [op, *args]: argument i is child
-                    # i + 1.
                     replace_path = (*root_path, relevant_pos[0] + 1)
                     removal_paths = [(*root_path, i + 1) for i in relevant_pos[1:]]
                 query_expr = MapJoin(Literal(op), tuple(relevant_args))
@@ -756,17 +680,40 @@ class AnnotatedQuery:
         agg_op = self.idx_op[self.original_idx[reduce_idx]]
         agg_init = self.idx_init[self.original_idx[reduce_idx]]
 
+        # An index absent from the extracted kernel is not reduced by iterating:
+        # applying the operator over |Dom(idx)| identical values is the repeat
+        # operator, i.e. sum_i B = B * |Dom(i)|.
+        kernel_order = stats_cache[query_expr].index_order
+        repeat_op = repeat_operator(agg_op)
+        repeated = (
+            []
+            if repeat_op is None
+            else [i for i in final_idxs_to_be_reduced if i not in kernel_order]
+        )
+        aggregated = [i for i in final_idxs_to_be_reduced if i not in repeated]
+
+        # The repeat factor goes under the aggregate, which is equivalent for
+        # these power-like operators (sum_j(K*n) == (sum_j K)*n) and keeps an
+        # Aggregate at the root, as the rest of the optimizer expects.
+        for idx in repeated:
+            factor = Literal(self.idx_dim_size[idx])
+            stats_cache[factor] = self.stats_factory(Scalar(factor.val), ())
+            repeated_expr = MapJoin(Literal(repeat_op), (query_expr, factor))
+            stats_cache[repeated_expr] = self.stats_factory.mapjoin(
+                repeat_op, stats_cache[query_expr], stats_cache[factor]
+            )
+            query_expr = repeated_expr
+
         query_expr = Aggregate(
             Literal(agg_op),
             Literal(agg_init),
             query_expr,
-            tuple(final_idxs_to_be_reduced),
+            tuple(aggregated),
         )
-
         stats_cache[query_expr] = self.stats_factory.aggregate(
             agg_op,
             agg_init,
-            tuple(final_idxs_to_be_reduced),
+            tuple(aggregated),
             stats_cache[query_expr.arg],
         )
 

--- a/src/finch/autoschedule/galley/logical_optimizer/annotated_query.py
+++ b/src/finch/autoschedule/galley/logical_optimizer/annotated_query.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from collections.abc import Collection, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -20,25 +20,22 @@ from finch.finch_logic import (
     Literal,
     LogicExpression,
     LogicNode,
+    LogicTree,
     MapJoin,
-    Plan,
     Query,
     Reorder,
     StatsFactory,
     Table,
     TensorStats,
 )
-from finch.symbolic import (
-    Chain,
-    PostWalk,
-    PreOrderDFS,
-    Rewrite,
-    gensym,
-    intree,
-    isdescendant,
-)
+from finch.symbolic import gensym
 
 from .logic_to_stats import insert_statistics
+
+# A location in an expression tree. Unlike a node value, a path identifies one
+# occurrence, so rewrites addressed by path cannot confuse structurally equal
+# subexpressions (e.g. two `Literal(2.0)` constants, repeated tables, ...).
+Path = tuple[int, ...]
 
 
 @dataclass
@@ -47,7 +44,7 @@ class AnnotatedQuery:
     output_name: Alias
     reduce_idxs: list[Field]
     point_expr: LogicExpression
-    idx_lowest_root: OrderedDict[Field, LogicExpression]
+    idx_lowest_path: OrderedDict[Field, Path]
     idx_op: OrderedDict[Field, Any]
     idx_init: OrderedDict[Field, Any]
     parent_idxs: OrderedDict[Field, list[Field]]
@@ -103,35 +100,57 @@ class AnnotatedQuery:
         else:
             output_order = None
         starting_reduce_idxs: list[Field] = []
-        idx_starting_root: OrderedDict[Field, LogicExpression] = OrderedDict()
+        idx_starting_path: OrderedDict[Field, Path] = OrderedDict()
         idx_top_order: OrderedDict[Field, int] = OrderedDict()
         top_counter = 1
         idx_op: OrderedDict[Field, FinchOperator] = OrderedDict()
         idx_init: OrderedDict[Field, Any] = OrderedDict()
 
-        def aggregate_annotation_rule(node: LogicNode) -> LogicNode:
-            nonlocal top_counter
+        def strip_aggregates(
+            node: LogicNode,
+        ) -> tuple[LogicNode, list[tuple[Field, Path, Literal, Literal, LogicNode]]]:
+            """Remove Aggregate nodes bottom-up, recording each reduction index
+            together with the path of the aggregate's argument in the stripped
+            tree. An aggregate collapses to its argument, so that path is the
+            aggregate's own position."""
             match node:
                 case Aggregate(Literal() as op, Literal() as init, arg, idxs):
+                    new_arg, records = strip_aggregates(arg)
                     for idx in idxs:
-                        idx_starting_root[idx] = arg
-                        idx_top_order[idx] = top_counter
-                        top_counter += 1
-
-                        if op.val is None:
-                            idx_op[idx] = ffuncs.init_write(cache[arg].fill_value)
-                            idx_init[idx] = cache[arg].fill_value
-                        else:
-                            idx_op[idx] = op.val
-                            idx_init[idx] = init.val
-
-                        starting_reduce_idxs.append(idx)
-                    return arg
-
+                        records.append((idx, (), op, init, new_arg))
+                    return new_arg, records
+                case LogicTree():
+                    children = node.children
+                    new_children = []
+                    records = []
+                    for i, child in enumerate(children):
+                        new_child, child_records = strip_aggregates(child)
+                        new_children.append(new_child)
+                        records.extend(
+                            (idx, (i, *path), op, init, arg)
+                            for idx, path, op, init, arg in child_records
+                        )
+                    if new_children != children:
+                        node = type(node).from_children(*new_children)
+                    return node, records
                 case _:
-                    return node
+                    return node, []
 
-        point_expr = Rewrite(PostWalk(Chain([aggregate_annotation_rule])))(expr)
+        point_expr, agg_records = strip_aggregates(expr)
+        for idx, agg_path, op_lit, init_lit, agg_arg in agg_records:
+            idx_starting_path[idx] = agg_path
+            idx_top_order[idx] = top_counter
+            top_counter += 1
+
+            if op_lit.val is None:
+                idx_op[idx] = ffuncs.init_write(cache[agg_arg].fill_value)
+                idx_init[idx] = cache[agg_arg].fill_value
+            else:
+                idx_op[idx] = op_lit.val
+                idx_init[idx] = init_lit.val
+
+            starting_reduce_idxs.append(idx)
+
         cache_point: dict[object, TensorStats] = {}
         insert_statistics(
             self.stats_factory,
@@ -146,24 +165,33 @@ class AnnotatedQuery:
         original_idx: OrderedDict[Field, Field] = OrderedDict(
             (idx, idx) for idx in cache[q.rhs].index_order
         )
-        idx_lowest_root: OrderedDict[Field, LogicExpression] = OrderedDict()
+        idx_lowest_path: OrderedDict[Field, Path] = OrderedDict()
+        repeats: dict[Path, OrderedDict[Field, tuple[FinchOperator, Any]]] = {}
+        stats_point = cache_point[point_expr]
         for idx in starting_reduce_idxs:
             agg_op = idx_op[idx]
-            stats_point = cache_point[point_expr]
             idx_dim_size = stats_point.dim_sizes[idx]
-            lowest_roots = AnnotatedQuery.find_lowest_roots(
-                agg_op, idx, idx_starting_root[idx]
+            starting_path = idx_starting_path[idx]
+            lowest_paths = AnnotatedQuery.find_lowest_roots(
+                agg_op,
+                idx,
+                cast(
+                    LogicExpression,
+                    AnnotatedQuery.node_at(point_expr, starting_path),
+                ),
+                base=starting_path,
             )
             original_idx[idx] = idx
-            if len(lowest_roots) == 1:
-                idx_lowest_root[idx] = cast(LogicExpression, lowest_roots[0])
+            if len(lowest_paths) == 1:
+                idx_lowest_path[idx] = lowest_paths[0]
                 reduce_idxs.append(idx)
             else:
                 new_idxs = [
                     Field(f"{idx.name}_{i}")
-                    for i, _ in enumerate(lowest_roots, start=1)
+                    for i, _ in enumerate(lowest_paths, start=1)
                 ]
-                for i, node in enumerate(lowest_roots):
+                for i, path in enumerate(lowest_paths):
+                    node = AnnotatedQuery.node_at(point_expr, path)
                     if idx not in cache_point[node].index_order:
                         # If the lowest root doesn't contain the reduction index, we
                         # attempt to remove the reduction via a repeat_operator, i.e.
@@ -171,32 +199,78 @@ class AnnotatedQuery:
                         f = repeat_operator(agg_op)
                         if f is None:
                             continue
-                        dim_val = Table(
-                            Literal(idx_dim_size),
-                            (),
-                        )
-                        cache_point[dim_val] = self.stats_factory(idx_dim_size, ())
-                        new_node = MapJoin(Literal(f), (node, dim_val))
-                        cache_point[new_node] = self.stats_factory.mapjoin(
-                            f, cache_point[node], cache_point[dim_val]
-                        )
-                        point_expr = cast(
-                            LogicExpression,
-                            AnnotatedQuery.replace_and_remove_nodes(
-                                point_expr,
-                                node_to_replace=node,
-                                new_node=new_node,
-                                nodes_to_remove=set(),
-                            ),
+                        repeats.setdefault(path, OrderedDict())[idx] = (
+                            f,
+                            idx_dim_size,
                         )
                         continue
                     new_idx = new_idxs[i]
                     idx_op[new_idx] = agg_op
                     idx_init[new_idx] = idx_init[idx]
-                    idx_lowest_root[new_idx] = cast(LogicExpression, node)
-                    idx_starting_root[new_idx] = idx_starting_root[idx]
+                    idx_lowest_path[new_idx] = path
+                    idx_starting_path[new_idx] = starting_path
                     original_idx[new_idx] = idx
                     reduce_idxs.append(new_idx)
+
+        if repeats:
+            # Repeats over several indices with the same operator compose by
+            # multiplying their domain sizes, since the repeat operators are
+            # power-like: (x*d1)*d2 == x*(d1*d2) and (x**d1)**d2 == x**(d1*d2).
+            wrap_groups: dict[Path, list[tuple[FinchOperator, Any]]] = {}
+            for path, per_idx in repeats.items():
+                groups: list[tuple[FinchOperator, Any]] = []
+                for f, size in per_idx.values():
+                    if groups and groups[-1][0] == f:
+                        groups[-1] = (f, groups[-1][1] * size)
+                    else:
+                        groups.append((f, size))
+                wrap_groups[path] = groups
+
+            def make_wrap(
+                groups: list[tuple[FinchOperator, Any]],
+            ) -> Callable[[LogicNode], LogicNode]:
+                def wrap(node: LogicNode) -> LogicNode:
+                    for f, factor in groups:
+                        node = MapJoin(
+                            Literal(f),
+                            (cast(LogicExpression, node), Literal(factor)),
+                        )
+                    return node
+
+                return wrap
+
+            point_expr = cast(
+                LogicExpression,
+                AnnotatedQuery.replace_at(
+                    point_expr,
+                    {path: make_wrap(g) for path, g in wrap_groups.items()},
+                ),
+            )
+            # Wrapping inserts MapJoin levels above the wrapped nodes, so every
+            # stored path running through a wrapped position must be remapped.
+            # The wrapped node sits at child 1 of each inserted MapJoin
+            # (children are [op, node, factor]).
+            wrap_paths = sorted(wrap_groups, key=len, reverse=True)
+
+            def remap_through_wraps(path: Path) -> Path:
+                for p in wrap_paths:
+                    if path[: len(p)] == p:
+                        levels = (1,) * len(wrap_groups[p])
+                        path = (*p, *levels, *path[len(p) :])
+                return path
+
+            for idx, path in idx_lowest_path.items():
+                idx_lowest_path[idx] = remap_through_wraps(path)
+            for idx, path in idx_starting_path.items():
+                idx_starting_path[idx] = remap_through_wraps(path)
+            insert_statistics(
+                self.stats_factory,
+                point_expr,
+                bindings=bindings,
+                replace=False,
+                cache=cache_point,
+            )
+
         parent_idxs: OrderedDict[Field, list[Field]] = OrderedDict(
             (i, []) for i in reduce_idxs
         )
@@ -205,12 +279,13 @@ class AnnotatedQuery:
         )
         for idx1 in reduce_idxs:
             idx1_op = idx_op[idx1]
-            idx1_bottom_root = idx_lowest_root[idx1]
+            idx1_bottom = idx_lowest_path[idx1]
             for idx2 in reduce_idxs:
                 idx2_op = idx_op[idx2]
-                idx2_top_root = idx_starting_root[idx2]
-                idx2_bottom_root = idx_lowest_root[idx2]
-                if intree(idx2_bottom_root, idx1_bottom_root):
+                idx2_top = idx_starting_path[idx2]
+                idx2_bottom = idx_lowest_path[idx2]
+                # idx2's lowest root lies within idx1's lowest root subtree.
+                if idx2_bottom[: len(idx1_bottom)] == idx1_bottom:
                     connected_idxs[idx1].add(idx2)
                 mergeable_agg_op = (
                     idx1_op == idx2_op
@@ -218,8 +293,12 @@ class AnnotatedQuery:
                     and is_commutative(idx1_op)
                 )
                 # If idx1 isn't a parent of idx2, then idx2 can't restrict the
-                # summation of idx1
-                if isdescendant(idx2_top_root, idx1_bottom_root) or (
+                # summation of idx1. idx2 is a parent when its starting root
+                # lies strictly within idx1's lowest root subtree.
+                if (
+                    len(idx2_top) > len(idx1_bottom)
+                    and idx2_top[: len(idx1_bottom)] == idx1_bottom
+                ) or (
                     not mergeable_agg_op
                     and idx_top_order[original_idx[idx2]]
                     < idx_top_order[original_idx[idx1]]
@@ -232,8 +311,8 @@ class AnnotatedQuery:
 
         self.output_name = output_name
         self.reduce_idxs = reduce_idxs
-        self.point_expr = point_expr
-        self.idx_lowest_root = idx_lowest_root
+        self.point_expr = cast(LogicExpression, point_expr)
+        self.idx_lowest_path = idx_lowest_path
         self.idx_op = idx_op
         self.idx_init = idx_init
         self.parent_idxs = parent_idxs
@@ -251,7 +330,7 @@ class AnnotatedQuery:
         new.output_name = self.output_name
         new.point_expr = self.point_expr
         new.reduce_idxs = list(self.reduce_idxs)
-        new.idx_lowest_root = OrderedDict(self.idx_lowest_root.items())
+        new.idx_lowest_path = OrderedDict(self.idx_lowest_path.items())
         new.idx_op = OrderedDict(self.idx_op.items())
         new.idx_init = OrderedDict(self.idx_init.items())
         new.parent_idxs = OrderedDict((m, list(n)) for m, n in self.parent_idxs.items())
@@ -401,117 +480,163 @@ class AnnotatedQuery:
         return components
 
     @staticmethod
-    def replace_and_remove_nodes(
-        expr: LogicExpression,
-        node_to_replace: LogicExpression,
-        new_node: LogicExpression,
-        nodes_to_remove: Collection[LogicExpression],
-    ) -> LogicExpression:
+    def node_at(root: LogicNode, path: Path) -> LogicNode:
         """
-        Replace and/or remove arguments of a pointwise MapJoin expression.
+        Return the node at `path`, a sequence of child indices from `root`.
+        """
+        node = root
+        for i in path:
+            node = cast(LogicTree, node).children[i]
+        return node
+
+    @staticmethod
+    def replace_at(
+        root: LogicNode,
+        transforms: Mapping[Path, Callable[[LogicNode], LogicNode | None]],
+    ) -> LogicNode:
+        """
+        Rebuild `root`, applying each transform to the node at its path.
 
         Parameters
         ----------
-        expr : LogicExpression
-            The expression to transform. Typically a `MapJoin` in a pointwise
-            subexpression.
-        node_to_replace : LogicExpression
-            The node to replace when it appears as an argument to `expr`, or as
-            `expr` itself.
-        new_node : LogicExpression
-            The node that replaces `node_to_replace` wherever it is found.
-        nodes_to_remove : Collection[LogicExpression]
-            A collection of nodes that, if present as arguments to a `MapJoin`,
-            should be removed from its argument list.
+        root : LogicNode
+            The expression to transform.
+        transforms : Mapping[Path, Callable[[LogicNode], LogicNode | None]]
+            For each path, a function from the node at that position to its
+            replacement. Returning None removes the node, which is only
+            meaningful for MapJoin arguments. All paths address positions in
+            the original tree.
 
         Returns
         -------
-        LogicExpression
-            A `MapJoin` node with updated arguments if `expr` is a `MapJoin`,
-            `new_node` if `expr == node_to_replace`, or the original `expr`
-            otherwise.
+        LogicNode
+            `root` with every transform applied.
+
+        Notes
+        -----
+        Children are rebuilt before a node's own transform runs, so nested
+        transform paths compose (an outer transform receives the node with
+        inner transforms already applied), and the single traversal never
+        descends into subtrees a transform inserted -- an inserted node can
+        never itself be matched, which is what makes wrapping a node in an
+        expression that contains it safe.
         """
-        nodes_to_remove_set = set(nodes_to_remove)
 
-        def replace_remove_rule(node: LogicExpression) -> LogicExpression | None:
-            match node:
-                case Plan(_) | Query(_, _) | Aggregate(_, _, _, _) as illegal:
-                    raise ValueError(
-                        f"There should be no {type(illegal).__name__} "
-                        "nodes in a pointwise expression."
-                    )
-                case node if (
-                    node == node_to_replace and node not in nodes_to_remove_set
-                ):
-                    return new_node
-                case node if node in nodes_to_remove_set:
-                    return None
-                case MapJoin(op, args) if any(
-                    (arg == node_to_replace) or (arg in nodes_to_remove_set)
-                    for arg in args
-                ):
-                    new_args = []
-                    for arg in args:
-                        if arg in nodes_to_remove_set:
-                            continue
-                        if arg == node_to_replace:
-                            new_args.append(new_node)
-                        else:
-                            new_args.append(arg)
-                    if len(new_args) == 1:
-                        return new_args[0]
-                    return MapJoin(op, tuple(new_args))
-                case _:
-                    return None
+        def rebuild(node: LogicNode, path: Path) -> LogicNode | None:
+            if isinstance(node, LogicTree) and any(
+                len(p) > len(path) and p[: len(path)] == path for p in transforms
+            ):
+                children = node.children
+                new_children = []
+                for i, child in enumerate(children):
+                    new_child = rebuild(child, (*path, i))
+                    if new_child is None:
+                        if not isinstance(node, MapJoin):
+                            raise ValueError(
+                                "Only MapJoin arguments can be removed, not "
+                                f"children of {type(node).__name__}."
+                            )
+                        continue
+                    new_children.append(new_child)
+                if new_children != children:
+                    node = type(node).from_children(*new_children)
+            transform = transforms.get(path)
+            if transform is not None:
+                return transform(node)
+            return node
 
-        return Rewrite(PostWalk(Chain([replace_remove_rule])))(expr)
+        result = rebuild(root, ())
+        if result is None:
+            raise ValueError("Cannot remove the root of an expression.")
+        return result
+
+    @staticmethod
+    def splice_paths(
+        path: Path, replace_path: Path, removal_paths: Iterable[Path]
+    ) -> Path:
+        """
+        Remap `path` through a splice: the node at `replace_path` was replaced
+        and the MapJoin arguments at `removal_paths` (siblings of
+        `replace_path`) were removed, shifting the positions of the arguments
+        after them. Paths inside the replaced or removed subtrees map to the
+        replacement's position, since the kernel they addressed now lives
+        behind it.
+        """
+        removal_paths = list(removal_paths)
+        if path[: len(replace_path)] == replace_path or any(
+            path[: len(r)] == r for r in removal_paths
+        ):
+            path = replace_path
+        for parent in {r[:-1] for r in removal_paths}:
+            if len(path) > len(parent) and path[: len(parent)] == parent:
+                child = path[len(parent)]
+                child -= sum(
+                    1 for r in removal_paths if r[:-1] == parent and r[-1] < child
+                )
+                path = (*parent, child, *path[len(parent) + 1 :])
+        return path
 
     @staticmethod
     def find_lowest_roots(
-        op: FinchOperator, idx: Field, root: LogicExpression
-    ) -> list[LogicExpression]:
+        op: FinchOperator, idx: Field, root: LogicExpression, base: Path = ()
+    ) -> list[Path]:
         """
-        Compute the lowest MapJoin / leaf nodes that a reduction over `idx` can be
-        safely pushed down to in a logical expression.
+        Compute the lowest MapJoin / leaf positions that a reduction over `idx`
+        can be safely pushed down to in a logical expression.
 
         Parameters
         ----------
-        op : Literal
-            The reduction operator node (e.g., Literal(ffunc.add))
-            that we are trying to push down.
+        op : FinchOperator
+            The reduction operator (e.g., ffuncs.add) that we are trying to
+            push down.
         idx : Field
             The index (dimension) being reduced over.
         root : LogicExpression
             The root logical expression under which we search for the lowest
             pushdown positions for the reduction.
+        base : Path
+            The path of `root` in the enclosing expression; returned paths
+            extend it.
 
         Returns
         -------
-        list[LogicExpression]
-            A list of expression nodes representing the lowest positions in
-            the expression tree where the reduction over `idx` with operator
-            `op` can be safely pushed down.
+        list[Path]
+            The paths of the lowest positions in the expression tree where the
+            reduction over `idx` with operator `op` can be safely pushed down.
+            Paths address occurrences, so structurally equal subexpressions at
+            different positions are reported separately.
         """
         match root:
-            case MapJoin(Literal(FinchOperator() as mj_op), args) as mj:
-                args_with = [arg for arg in args if idx in arg.fields()]
-                args_without = [arg for arg in args if idx not in arg.fields()]
+            case MapJoin(Literal(FinchOperator() as mj_op), args):
+                # A MapJoin's children are [op, *args]: argument i is child
+                # i + 1.
+                with_idx = [
+                    (i, arg) for i, arg in enumerate(args) if idx in arg.fields()
+                ]
+                without_idx = [
+                    (i, arg) for i, arg in enumerate(args) if idx not in arg.fields()
+                ]
 
-                if len(args_with) == 1 and is_distributive(mj_op, op):
-                    return AnnotatedQuery.find_lowest_roots(op, idx, args_with[0])
+                if len(with_idx) == 1 and is_distributive(mj_op, op):
+                    i, arg = with_idx[0]
+                    return AnnotatedQuery.find_lowest_roots(
+                        op, idx, arg, (*base, i + 1)
+                    )
 
                 if cansplitpush(op, mj_op):
-                    roots_without: list[LogicExpression] = list(args_without)
-                    roots_with: list[LogicExpression] = []
-                    for arg in args_with:
+                    roots_without = [(*base, i + 1) for i, _ in without_idx]
+                    roots_with: list[Path] = []
+                    for i, arg in with_idx:
                         roots_with.extend(
-                            AnnotatedQuery.find_lowest_roots(op, idx, arg)
+                            AnnotatedQuery.find_lowest_roots(
+                                op, idx, arg, (*base, i + 1)
+                            )
                         )
                     return roots_without + roots_with
 
-                return [mj]
-            case Alias(_) | Table(_, _) | Reorder(_, _) as root:
-                return [root]
+                return [base]
+            case Alias(_) | Table(_, _) | Reorder(_, _) | Literal(_):
+                return [base]
             case _:
                 raise ValueError(
                     f"There shouldn't be nodes of type {type(root).__name__} "
@@ -520,7 +645,7 @@ class AnnotatedQuery:
 
     def get_reduce_query(
         self, reduce_idx: Field
-    ) -> tuple[Query, LogicExpression, set[LogicExpression], list[Field]]:
+    ) -> tuple[Query, Path, list[Path], list[Field]]:
         """
         Extract the maximal kernel that depends on `reduce_idx` into a standalone
         reduction query, and return the information needed to splice the result
@@ -530,35 +655,37 @@ class AnnotatedQuery:
         ----------
         reduce_idx : Field
             The index being reduced.
-        aq : AnnotatedQuery
-            The annotated query class
 
         Returns
         -------
         query : Query
             A new Query whose RHS is an Aggregate over the kernel that depends on
             `reduce_idx`.
-        node_to_replace : LogicExpression
-            The subexpression in `aq.point_expr` that will be replaced with the
+        replace_path : Path
+            The position in `self.point_expr` that will be replaced with the
             alias produced by `query`.
-        nodes_to_remove : set[LogicExpression]
-            Child nodes that become redundant after replacing `node_to_replace`.
+        removal_paths : list[Path]
+            Positions of MapJoin arguments (siblings of `replace_path`) that
+            become redundant after the replacement.
         reduced_idxs : list[Field]
             The list of indices actually reduced in `query`.
         """
         original_idx = self.original_idx[reduce_idx]
         reduce_op = self.idx_op[reduce_idx]
-        root_node: LogicExpression = self.idx_lowest_root[reduce_idx]
+        root_path = self.idx_lowest_path[reduce_idx]
+        root_node = cast(
+            LogicExpression, AnnotatedQuery.node_at(self.point_expr, root_path)
+        )
         query_expr: LogicExpression
         idxs_to_be_reduced: set[Field] = set()
-        nodes_to_remove: set[LogicExpression] = set()
-        node_to_replace: LogicExpression = root_node
+        replace_path: Path = root_path
+        removal_paths: list[Path] = []
         reducible_idxs = self.get_reducible_idxs()
         stats_cache = self.cache_point
 
         use_root = False
         match root_node:
-            case MapJoin(Literal(FinchOperator() as op), args) as mj if is_distributive(
+            case MapJoin(Literal(FinchOperator() as op), args) if is_distributive(
                 op, reduce_op
             ):
                 # If you're already reducing one index, then it may
@@ -571,49 +698,50 @@ class AnnotatedQuery:
                 kernel_idxs = set().union(
                     *(stats_cache[arg].index_order for arg in args_with_reduce_idx)
                 )
-                relevant_args = [
-                    arg
-                    for arg in args
+                relevant_pos = [
+                    i
+                    for i, arg in enumerate(args)
                     if set(stats_cache[arg].index_order).issubset(kernel_idxs)
                 ]
-                if len(relevant_args) == len(args):
-                    node_to_replace = mj
+                relevant_args = [args[i] for i in relevant_pos]
+                if len(relevant_pos) == len(args):
+                    replace_path = root_path
                 else:
-                    node_to_replace = relevant_args[0]
-                    for arg in relevant_args[1:]:
-                        for node in PreOrderDFS(arg):
-                            nodes_to_remove.add(cast(LogicExpression, node))
+                    # A MapJoin's children are [op, *args]: argument i is child
+                    # i + 1.
+                    replace_path = (*root_path, relevant_pos[0] + 1)
+                    removal_paths = [(*root_path, i + 1) for i in relevant_pos[1:]]
                 query_expr = MapJoin(Literal(op), tuple(relevant_args))
                 stats_cache[query_expr] = self.stats_factory.mapjoin(
                     op, *[stats_cache[arg] for arg in relevant_args]
                 )
-                relevant_args_set = set(relevant_args)
+                relevant_pos_set = set(relevant_pos)
                 for idx in reducible_idxs:
                     if self.idx_op[idx] != self.idx_op[reduce_idx]:
                         continue
 
-                    args_with_idx = [
-                        arg
-                        for arg in args
+                    pos_with_idx = {
+                        i
+                        for i, arg in enumerate(args)
                         if self.original_idx[idx] in stats_cache[arg].index_order
-                    ]
+                    }
                     if idx in self.connected_idxs[
                         reduce_idx
-                    ] and relevant_args_set.issuperset(args_with_idx):
+                    ] and relevant_pos_set.issuperset(pos_with_idx):
                         idxs_to_be_reduced.add(idx)
             case _:
                 use_root = True
 
         if use_root:
             query_expr = root_node
-            node_to_replace = root_node
+            replace_path = root_path
             reducible_idxs = self.get_reducible_idxs()
             for idx in reducible_idxs:
                 if self.idx_op[idx] != self.idx_op[reduce_idx]:
                     continue
                 if (
                     idx in self.connected_idxs[reduce_idx]
-                    or self.idx_lowest_root[idx] == node_to_replace
+                    or self.idx_lowest_path[idx] == root_path
                 ):
                     idxs_to_be_reduced.add(idx)
 
@@ -643,7 +771,7 @@ class AnnotatedQuery:
         )
 
         query = Query(Alias(gensym("A")), query_expr)
-        return query, node_to_replace, nodes_to_remove, reduced_idxs
+        return query, replace_path, removal_paths, reduced_idxs
 
     def reduce_idx(self, reduce_idx: Field, do_condense: bool = False) -> Query:
         """
@@ -674,7 +802,7 @@ class AnnotatedQuery:
             The newly created `Query` whose RHS computes the reduced kernel; its
             alias is used in the updated `aq.point_expr`.
         """
-        query, node_to_replace, nodes_to_remove, reduced_idxs = self.get_reduce_query(
+        query, replace_path, removal_paths, reduced_idxs = self.get_reduce_query(
             reduce_idx
         )
 
@@ -689,34 +817,28 @@ class AnnotatedQuery:
         )
         alias_idxs = list(self.bindings[alias_expr].index_order)
 
-        new_point_expr: LogicExpression = AnnotatedQuery.replace_and_remove_nodes(
-            expr=cast(LogicExpression, self.point_expr),
-            node_to_replace=node_to_replace,
-            new_node=Table(alias_expr, tuple(alias_idxs)),
-            nodes_to_remove=nodes_to_remove,
+        alias_table = Table(alias_expr, tuple(alias_idxs))
+        transforms: dict[Path, Callable[[LogicNode], LogicNode | None]] = {
+            replace_path: lambda _node: alias_table
+        }
+        for removal_path in removal_paths:
+            transforms[removal_path] = lambda _node: None
+        new_point_expr = cast(
+            LogicExpression,
+            AnnotatedQuery.replace_at(self.point_expr, transforms),
         )
         new_reduce_idxs = [x for x in self.reduce_idxs if x not in reduced_idxs]
-        new_idx_lowest_root: OrderedDict[Field, LogicExpression] = OrderedDict()
+        new_idx_lowest_path: OrderedDict[Field, Path] = OrderedDict()
         new_idx_op: OrderedDict[Field, Any] = OrderedDict()
         new_idx_init: OrderedDict[Field, Any] = OrderedDict()
         new_parent_idxs: OrderedDict[Field, list[Field]] = OrderedDict()
         new_connected_idxs: OrderedDict[Field, set[Field]] = OrderedDict()
-        alias_table = Table(alias_expr, tuple(alias_idxs))
-        for idx in self.idx_lowest_root:
+        for idx in self.idx_lowest_path:
             if idx in reduced_idxs:
                 continue
-            root = self.idx_lowest_root[idx]
-            if root == node_to_replace or root in nodes_to_remove:
-                root = alias_table
-            else:
-                root = AnnotatedQuery.replace_and_remove_nodes(
-                    root,
-                    node_to_replace,
-                    alias_table,
-                    nodes_to_remove,
-                )
-
-            new_idx_lowest_root[idx] = root
+            new_idx_lowest_path[idx] = AnnotatedQuery.splice_paths(
+                self.idx_lowest_path[idx], replace_path, removal_paths
+            )
             new_idx_op[idx] = self.idx_op[idx]
             new_idx_init[idx] = self.idx_init[idx]
             new_idx_op[self.original_idx[idx]] = self.idx_op[idx]
@@ -728,9 +850,9 @@ class AnnotatedQuery:
                 x for x in self.connected_idxs.get(idx, set()) if x not in reduced_idxs
             }
 
-        for idx in new_idx_lowest_root:
-            for idx2 in new_idx_lowest_root:
-                if new_idx_lowest_root[idx] is new_idx_lowest_root[idx2]:
+        for idx in new_idx_lowest_path:
+            for idx2 in new_idx_lowest_path:
+                if new_idx_lowest_path[idx] == new_idx_lowest_path[idx2]:
                     new_connected_idxs[idx].add(idx2)
                     new_connected_idxs[idx2].add(idx)
 
@@ -748,7 +870,7 @@ class AnnotatedQuery:
 
         self.reduce_idxs = new_reduce_idxs
         self.point_expr = new_point_expr
-        self.idx_lowest_root = new_idx_lowest_root
+        self.idx_lowest_path = new_idx_lowest_path
         self.idx_op = new_idx_op
         self.idx_init = new_idx_init
         self.parent_idxs = new_parent_idxs

--- a/src/finch/autoschedule/galley/logical_optimizer/logic_to_stats.py
+++ b/src/finch/autoschedule/galley/logical_optimizer/logic_to_stats.py
@@ -12,6 +12,7 @@ from finch.finch_logic import (
     Table,
     TensorStats,
 )
+from finch.tensor import Scalar
 
 
 def insert_statistics(
@@ -80,6 +81,13 @@ def insert_statistics(
             if (node not in cache) or replace:
                 cache[node] = tensor
             return cache[node]
+
+        case Literal(val):
+            # A literal is a zero-dimensional constant, so its statistics are
+            # those of a rank-0 dense tensor holding that value.
+            st = stats_factory(Scalar(val), ())
+            cache[node] = st
+            return st
 
         case _:
             raise TypeError(f"Unhandled node type: {type(node)}")

--- a/src/finch/autoschedule/tensor_stats/stats_interpreter.py
+++ b/src/finch/autoschedule/tensor_stats/stats_interpreter.py
@@ -124,8 +124,6 @@ class StatsMachine:
                 return self.stats_factory.aggregate(op, init, reduce_indices, arg2)
 
             case Literal(val):
-                # A literal is a zero-dimensional constant, so its statistics
-                # are those of a rank-0 dense tensor holding that value.
                 return self.stats_factory(Scalar(val), ())
 
             case Reorder():

--- a/src/finch/autoschedule/tensor_stats/stats_interpreter.py
+++ b/src/finch/autoschedule/tensor_stats/stats_interpreter.py
@@ -24,6 +24,7 @@ from finch.finch_logic import (
     StatsFactory,
     Table,
 )
+from finch.tensor import Scalar
 from finch.util.logging import LOG_LOGIC_PRE_OPT
 
 from .numeric_stats import NumericStats
@@ -121,6 +122,11 @@ class StatsMachine:
                 arg2 = self(node.arg)
                 reduce_indices = node.idxs
                 return self.stats_factory.aggregate(op, init, reduce_indices, arg2)
+
+            case Literal(val):
+                # A literal is a zero-dimensional constant, so its statistics
+                # are those of a rank-0 dense tensor holding that value.
+                return self.stats_factory(Scalar(val), ())
 
             case Reorder():
                 return self(node.arg)

--- a/src/finch/autoschedule/util.py
+++ b/src/finch/autoschedule/util.py
@@ -5,6 +5,7 @@ from finch.algebra.utils import intersect, is_subsequence, setdiff, with_subsequ
 from finch.finch_logic import (
     Aggregate,
     Alias,
+    Literal,
     LogicExpression,
     LogicNode,
     LogicStatement,
@@ -51,6 +52,9 @@ def push_fields(root):
                 return Reorder(Relabel(arg, idxs_4), idxs_2)
             case Relabel(Table(arg, _), idxs):
                 return Table(arg, idxs)
+            # A literal is zero-dimensional, so there are no fields to relabel.
+            case Relabel(Literal() as lit, _):
+                return lit
 
     root = Rewrite(PreWalk(Fixpoint(rule_1)))(root)  # ignore[type-arg]
 

--- a/src/finch/autoschedule/util.py
+++ b/src/finch/autoschedule/util.py
@@ -52,7 +52,6 @@ def push_fields(root):
                 return Reorder(Relabel(arg, idxs_4), idxs_2)
             case Relabel(Table(arg, _), idxs):
                 return Table(arg, idxs)
-            # A literal is zero-dimensional, so there are no fields to relabel.
             case Relabel(Literal() as lit, _):
                 return lit
 

--- a/src/finch/finch_logic/interpreter.py
+++ b/src/finch/finch_logic/interpreter.py
@@ -84,9 +84,14 @@ class LogicMachine:
                 return val
             case MapJoin(Literal(op), args):
                 args = tuple(self(a) for a in args)
+                # Literal arguments evaluate to plain scalars. They are
+                # zero-dimensional, so they broadcast across every index rather
+                # than contributing dimensions of their own.
                 dims = {}
                 idxs = []
                 for arg in args:
+                    if not isinstance(arg, TableValue):
+                        continue
                     for idx, dim in zip(arg.idxs, arg.tns.shape, strict=True):
                         if idx in dims:
                             if dims[idx] != dim:
@@ -94,8 +99,21 @@ class LogicMachine:
                         else:
                             idxs.append(idx)
                             dims[idx] = dim
-                fill_val = op(*[arg.tns.fill_value for arg in args])
-                dtype = return_type(op, *[arg.tns.element_type for arg in args])
+                fill_val = op(
+                    *[
+                        arg.tns.fill_value if isinstance(arg, TableValue) else arg
+                        for arg in args
+                    ]
+                )
+                dtype = return_type(
+                    op,
+                    *[
+                        arg.tns.element_type
+                        if isinstance(arg, TableValue)
+                        else ftype(arg)
+                        for arg in args
+                    ],
+                )
                 result = self.make_tensor(
                     tuple(dims[idx] for idx in idxs), fill_val, dtype=dtype
                 )
@@ -103,6 +121,8 @@ class LogicMachine:
                     idx_crds = dict(zip(idxs, crds, strict=True))
                     vals = [
                         arg.tns[*[idx_crds[idx] for idx in arg.idxs]].item()
+                        if isinstance(arg, TableValue)
+                        else arg
                         for arg in args
                     ]
                     result[*crds] = op(*vals)

--- a/src/finch/finch_logic/interpreter.py
+++ b/src/finch/finch_logic/interpreter.py
@@ -9,11 +9,10 @@ from finch.algebra.tensor import TensorFType
 from finch.codegen.numba_codegen import to_numpy_type
 from finch.finch_assembly import AssemblyKernel, AssemblyLibrary
 from finch.symbolic import UnvalidatedForm
+from finch.tensor.scalar import Scalar
 from finch.util.logging import LOG_LOGIC_PRE_OPT
 
 from . import nodes as lgc
-from finch.tensor.scalar import Scalar
-
 from .nodes import (
     Aggregate,
     Alias,

--- a/src/finch/finch_logic/interpreter.py
+++ b/src/finch/finch_logic/interpreter.py
@@ -12,6 +12,8 @@ from finch.symbolic import UnvalidatedForm
 from finch.util.logging import LOG_LOGIC_PRE_OPT
 
 from . import nodes as lgc
+from finch.tensor.scalar import Scalar
+
 from .nodes import (
     Aggregate,
     Alias,
@@ -62,7 +64,10 @@ class LogicMachine:
         logger.debug("Evaluating: %s", node)
         match node:
             case Literal(val):
-                return val
+                # A literal is a zero-dimensional tensor, so it evaluates to a
+                # rank-0 TableValue and every consumer below can treat it
+                # uniformly rather than special-casing raw scalars.
+                return TableValue(Scalar(val), ())
             case Value(_):
                 raise ValueError(
                     "The interpreter cannot evaluate a lazy node. Instead, you can "
@@ -87,8 +92,6 @@ class LogicMachine:
                 dims = {}
                 idxs = []
                 for arg in args:
-                    if not isinstance(arg, TableValue):
-                        continue
                     for idx, dim in zip(arg.idxs, arg.tns.shape, strict=True):
                         if idx in dims:
                             if dims[idx] != dim:
@@ -96,21 +99,8 @@ class LogicMachine:
                         else:
                             idxs.append(idx)
                             dims[idx] = dim
-                fill_val = op(
-                    *[
-                        arg.tns.fill_value if isinstance(arg, TableValue) else arg
-                        for arg in args
-                    ]
-                )
-                dtype = return_type(
-                    op,
-                    *[
-                        arg.tns.element_type
-                        if isinstance(arg, TableValue)
-                        else ftype(arg)
-                        for arg in args
-                    ],
-                )
+                fill_val = op(*[arg.tns.fill_value for arg in args])
+                dtype = return_type(op, *[arg.tns.element_type for arg in args])
                 result = self.make_tensor(
                     tuple(dims[idx] for idx in idxs), fill_val, dtype=dtype
                 )
@@ -118,8 +108,6 @@ class LogicMachine:
                     idx_crds = dict(zip(idxs, crds, strict=True))
                     vals = [
                         arg.tns[*[idx_crds[idx] for idx in arg.idxs]].item()
-                        if isinstance(arg, TableValue)
-                        else arg
                         for arg in args
                     ]
                     result[*crds] = op(*vals)

--- a/src/finch/finch_logic/interpreter.py
+++ b/src/finch/finch_logic/interpreter.py
@@ -84,9 +84,6 @@ class LogicMachine:
                 return val
             case MapJoin(Literal(op), args):
                 args = tuple(self(a) for a in args)
-                # Literal arguments evaluate to plain scalars. They are
-                # zero-dimensional, so they broadcast across every index rather
-                # than contributing dimensions of their own.
                 dims = {}
                 idxs = []
                 for arg in args:

--- a/src/finch/finch_logic/nodes.py
+++ b/src/finch/finch_logic/nodes.py
@@ -267,9 +267,12 @@ class LogicStatement(LogicNode):
 
 
 @dataclass(eq=True, frozen=True)
-class Literal(LogicNode):
+class Literal(LogicExpression):
     """
     Represents a logical AST expression for the literal value `val`.
+
+    A literal behaves as a zero-dimensional tensor: it has no fields, and its
+    element type and fill value are those of `val` itself.
 
     Attributes:
         val: The literal value.
@@ -297,6 +300,36 @@ class Literal(LogicNode):
 
     def __repr__(self) -> str:
         return literal_repr(type(self).__name__, {"val": self.val})
+
+    def fields(self) -> tuple[Field, ...]:
+        """Returns fields of the node."""
+        return ()
+
+    def dimmap(
+        self,
+        op: Callable,
+        dim_bindings: dict[Alias, tuple[T | None, ...]],
+    ) -> tuple[T | None, ...]:
+        return ()
+
+    def valmap(
+        self,
+        f: Callable,
+        g: Callable,
+        bindings: dict[Alias, T],
+    ) -> T:
+        return self.val
+
+    # `valmap` returns the raw value, which callers combining literals with
+    # other nodes normalize themselves (`return_type` applies `ftype` to its
+    # arguments). A bare literal is its own base case, so it must normalize.
+    def element_type(self, bindings: dict[Alias, FType]) -> FType:
+        """Returns element type of the node."""
+        return ftype(self.val)
+
+    def fill_value(self, bindings: dict[Alias, Any]) -> Any:
+        """Returns fill value of the node."""
+        return self.val
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/finch/finch_logic/nodes.py
+++ b/src/finch/finch_logic/nodes.py
@@ -201,7 +201,7 @@ class LogicExpression(LogicNode):
 
     def element_type(self, bindings: dict[Alias, FType]) -> FType:
         """Returns element type of the node."""
-        return self.valmap(merge_element_type, reduce_element_type, bindings)
+        return ftype(self.valmap(merge_element_type, reduce_element_type, bindings))
 
     def fill_value(self, bindings: dict[Alias, Any]) -> Any:
         """Returns fill value of the node."""
@@ -318,17 +318,6 @@ class Literal(LogicExpression):
         g: Callable,
         bindings: dict[Alias, T],
     ) -> T:
-        return self.val
-
-    # `valmap` returns the raw value, which callers combining literals with
-    # other nodes normalize themselves (`return_type` applies `ftype` to its
-    # arguments). A bare literal is its own base case, so it must normalize.
-    def element_type(self, bindings: dict[Alias, FType]) -> FType:
-        """Returns element type of the node."""
-        return ftype(self.val)
-
-    def fill_value(self, bindings: dict[Alias, Any]) -> Any:
-        """Returns fill value of the node."""
         return self.val
 
 

--- a/src/finch/tests/test_galley_logical_optimizer.py
+++ b/src/finch/tests/test_galley_logical_optimizer.py
@@ -63,7 +63,7 @@ def test_get_reducible_idxs(reduce_idxs, parent_idxs, expected):
     aq.output_name = None
     aq.reduce_idxs = reduce_fields
     aq.point_expr = None
-    aq.idx_lowest_root = OrderedDict()
+    aq.idx_lowest_path = OrderedDict()
     aq.idx_op = OrderedDict()
     aq.idx_init = OrderedDict()
     aq.parent_idxs = parent_fields
@@ -114,7 +114,7 @@ def test_get_reducible_idxs_for_component(
     aq.output_name = None
     aq.reduce_idxs = reduce_fields
     aq.point_expr = None
-    aq.idx_lowest_root = OrderedDict()
+    aq.idx_lowest_path = OrderedDict()
     aq.idx_op = OrderedDict()
     aq.idx_init = OrderedDict()
     aq.parent_idxs = parent_fields
@@ -196,97 +196,96 @@ def test_get_idx_connected_components(parent_idxs, connected_idxs, expected):
     assert result == expected
 
 
-@pytest.mark.parametrize(
-    "expr,node_to_replace,new_node,nodes_to_remove,expected_names",
-    [
+def _abc_mapjoin():
+    return MapJoin(
+        Literal("op"),
         (
-            MapJoin(
-                Literal("op"),
-                (
-                    Table(Literal("a"), (Field("a"),)),
-                    Table(Literal("b"), (Field("b"),)),
-                    Table(Literal("c"), (Field("c"),)),
-                ),
-            ),
-            Table(Literal("b"), (Field("b"),)),
             Table(Literal("a"), (Field("a"),)),
-            set(),
-            ["a", "a", "c"],
+            Table(Literal("b"), (Field("b"),)),
+            Table(Literal("c"), (Field("c"),)),
         ),
+    )
+
+
+def test_node_at():
+    expr = _abc_mapjoin()
+    assert AnnotatedQuery.node_at(expr, ()) is expr
+    assert AnnotatedQuery.node_at(expr, (0,)) == Literal("op")
+    assert AnnotatedQuery.node_at(expr, (2,)) == Table(Literal("b"), (Field("b"),))
+    assert AnnotatedQuery.node_at(expr, (2, 0)) == Literal("b")
+
+
+@pytest.mark.parametrize(
+    "transforms,expected_names",
+    [
+        # Replace the second argument.
+        ({(2,): lambda _: Table(Literal("a"), (Field("a"),))}, ["a", "a", "c"]),
+        # Replace the second argument and remove the third.
         (
-            MapJoin(
-                Literal("op"),
-                (
-                    Table(Literal("a"), (Field("a"),)),
-                    Table(Literal("b"), (Field("b"),)),
-                    Table(Literal("c"), (Field("c"),)),
-                ),
-            ),
-            Table(Literal("b"), (Field("b"),)),
-            Table(Literal("a"), (Field("a"),)),
-            {Table(Literal("c"), (Field("c"),))},
+            {
+                (2,): lambda _: Table(Literal("a"), (Field("a"),)),
+                (3,): lambda _: None,
+            },
             ["a", "a"],
         ),
+        # Remove the first argument only; later siblings shift.
+        ({(1,): lambda _: None}, ["b", "c"]),
+        # Structurally equal replacements at different paths stay distinct:
+        # replacing the third argument does not touch an equal first argument.
         (
-            MapJoin(
-                Literal("op"),
-                (
-                    Table(Literal("a"), (Field("a"),)),
-                    Table(Literal("b"), (Field("b"),)),
-                    Table(Literal("c"), (Field("c"),)),
-                ),
-            ),
-            Table(Literal("c"), (Field("c"),)),
-            Table(Literal("a"), (Field("a"),)),
-            {Table(Literal("c"), (Field("c"),))},
-            ["a", "b"],
-        ),
-        (
-            MapJoin(
-                Literal("op"),
-                (
-                    Table(Literal("a"), (Field("a"),)),
-                    Table(Literal("b"), (Field("b"),)),
-                    Table(Literal("c"), (Field("c"),)),
-                ),
-            ),
-            Table(Literal("b"), (Field("b"),)),
-            Table(Literal("a"), (Field("a"),)),
-            {Table(Literal("b"), (Field("b"),))},
-            ["a", "c"],
-        ),
-        (
-            MapJoin(
-                Literal("op"),
-                (
-                    Table(Literal("a"), (Field("a"),)),
-                    Table(Literal("b"), (Field("b"),)),
-                    Table(Literal("c"), (Field("c"),)),
-                ),
-            ),
-            Table(Literal("c"), (Field("c"),)),
-            Table(Literal("a"), (Field("a"),)),
-            set(),
+            {(3,): lambda _: Table(Literal("a"), (Field("a"),))},
             ["a", "b", "a"],
         ),
     ],
 )
-def test_replace_and_remove_nodes(
-    expr,
-    node_to_replace,
-    new_node,
-    nodes_to_remove,
-    expected_names,
-):
-    out = AnnotatedQuery.replace_and_remove_nodes(
-        expr=expr,
-        node_to_replace=node_to_replace,
-        new_node=new_node,
-        nodes_to_remove=nodes_to_remove,
-    )
-
+def test_replace_at(transforms, expected_names):
+    out = AnnotatedQuery.replace_at(_abc_mapjoin(), transforms)
     result = [tbl.idxs[0].name for tbl in out.args]
     assert result == expected_names
+
+
+def test_replace_at_root():
+    replacement = Table(Literal("z"), (Field("z"),))
+    out = AnnotatedQuery.replace_at(_abc_mapjoin(), {(): lambda _: replacement})
+    assert out == replacement
+
+
+def test_replace_at_nested_transforms_compose():
+    # An outer wrap receives the node with the inner transform already
+    # applied, and the walk never descends into inserted subtrees even though
+    # the inserted expression contains its own transform target.
+    expr = _abc_mapjoin()
+    wrap = lambda node: MapJoin(Literal("wrap"), (node, Literal(2.0)))  # noqa: E731
+    out = AnnotatedQuery.replace_at(
+        expr,
+        {
+            (2,): wrap,
+            (2, 0): lambda _: Literal("b2"),
+        },
+    )
+    wrapped = out.args[1]
+    assert wrapped.op == Literal("wrap")
+    assert wrapped.args[0] == Table(Literal("b2"), (Field("b"),))
+    assert wrapped.args[1] == Literal(2.0)
+
+
+@pytest.mark.parametrize(
+    "path,replace_path,removal_paths,expected",
+    [
+        # Inside the replaced kernel -> the replacement position.
+        ((2, 0), (2,), [], (2,)),
+        # Inside a removed sibling -> the replacement position.
+        ((3, 0), (2,), [(3,)], (2,)),
+        # A later sibling of a removal shifts down.
+        ((3,), (1,), [(2,)], (2,)),
+        # An earlier sibling of a removal is unchanged.
+        ((1,), (2,), [(3,)], (1,)),
+        # A path above the splice is unchanged.
+        ((), (2,), [(3,)], ()),
+    ],
+)
+def test_splice_paths(path, replace_path, removal_paths, expected):
+    assert AnnotatedQuery.splice_paths(path, replace_path, removal_paths) == expected
 
 
 @pytest.mark.parametrize(
@@ -388,7 +387,8 @@ def test_replace_and_remove_nodes(
     ],
 )
 def test_find_lowest_roots(root, idx_name, expected):
-    roots = AnnotatedQuery.find_lowest_roots(ffuncs.add, Field(idx_name), root)
+    paths = AnnotatedQuery.find_lowest_roots(ffuncs.add, Field(idx_name), root)
+    roots = [AnnotatedQuery.node_at(root, path) for path in paths]
 
     # Special-case: the max(C(i), D(j)) example – we expect the MapJoin itself.
     if expected and not isinstance(expected[0], str):
@@ -532,7 +532,7 @@ def test_get_reduce_query(expr, reduce_field, expected):
     aq.output_name = None
     aq.reduce_idxs = [reduce_field]
     aq.point_expr = expr
-    aq.idx_lowest_root = OrderedDict({reduce_field: expr.arg})
+    aq.idx_lowest_path = OrderedDict({reduce_field: (2,)})
     aq.idx_op = OrderedDict({reduce_field: ffuncs.add})
     aq.idx_init = OrderedDict({reduce_field: 0})
     aq.parent_idxs = OrderedDict()
@@ -558,9 +558,7 @@ def test_get_reduce_query(expr, reduce_field, expected):
             if isinstance(i, str):
                 dims[Field(i)] = dims[i]
 
-    query, node_to_replace, nodes_to_remove, reduced_idxs = aq.get_reduce_query(
-        reduce_field
-    )
+    query, replace_path, removal_paths, reduced_idxs = aq.get_reduce_query(reduce_field)
 
     assert query.rhs == expected
 
@@ -699,7 +697,7 @@ def test_reduce_idx(expr, reduce_field, expected_query, expected_point_expr):
     aq.output_name = None
     aq.reduce_idxs = [reduce_field]
     aq.point_expr = expr
-    aq.idx_lowest_root = OrderedDict({reduce_field: expr})
+    aq.idx_lowest_path = OrderedDict({reduce_field: ()})
     aq.idx_op = OrderedDict({reduce_field: ffuncs.add})
     aq.idx_init = OrderedDict({reduce_field: 0})
     aq.parent_idxs = OrderedDict()
@@ -770,7 +768,7 @@ def rename_aliases(expr):
                 Alias("out"),
                 Aggregate(
                     Literal(ffuncs.overwrite),
-                    Literal(0.0),
+                    Literal(np.float64(0.0)),
                     MapJoin(
                         Literal(ffuncs.mul),
                         (
@@ -803,7 +801,7 @@ def rename_aliases(expr):
                 Alias("out"),
                 Aggregate(
                     Literal(ffuncs.overwrite),
-                    Literal(0.0),
+                    Literal(np.float64(0.0)),
                     MapJoin(
                         Literal(ffuncs.mul),
                         (
@@ -838,7 +836,7 @@ def rename_aliases(expr):
                 Alias("out"),
                 Aggregate(
                     Literal(ffuncs.overwrite),
-                    Literal(0.0),
+                    Literal(np.float64(0.0)),
                     MapJoin(
                         Literal(ffuncs.mul),
                         (
@@ -1040,12 +1038,7 @@ def test_greedy_query_multi_component():
     aq.output_name = Alias("out")
     aq.reduce_idxs = [fi, fj]
     aq.point_expr = point_expr
-    aq.idx_lowest_root = OrderedDict(
-        {
-            fi: Table(Literal(A), (fi,)),
-            fj: Table(Literal(B), (fj,)),
-        }
-    )
+    aq.idx_lowest_path = OrderedDict({fi: (1,), fj: (2,)})
     aq.idx_op = OrderedDict(
         {
             fi: ffuncs.add,

--- a/src/finch/tests/test_galley_optimizer_pipeline.py
+++ b/src/finch/tests/test_galley_optimizer_pipeline.py
@@ -2,6 +2,8 @@
 Galley optimizer pipeline tests.
 """
 
+import pytest
+
 import numpy as np
 
 import finch.interface as fl_interface
@@ -366,3 +368,78 @@ def test_multiple_compute():
     expected = ((np.array(A) @ np.array(B)), (np.array(C) @ np.array(D)))
     assert np.allclose(np.array(out[0]), np.array(expected[0]))
     assert np.allclose(np.array(out[1]), np.array(expected[1]))
+
+
+# --- Scalar constants reduced via a repeat operator ---
+@pytest.mark.parametrize("scalar", [2, 2.0, 3, 3.0, 6.0])
+@pytest.mark.parametrize("axis", [None, 0, 1])
+def test_repeat_operator_scalar_literal(scalar, axis):
+    """
+    Reducing an expression whose scalar operand is a bare `Literal` sends galley
+    down the repeat-operator path (sum_i c = c*|Dom(i)|, prod_i c = c**|Dom(i)|).
+
+    The domain size is itself a Literal, and literals compare by value, so the
+    rewrite has to be applied in one pass with one combined factor. Rewriting
+    one reduction index at a time let the next index match inside the subtree
+    just inserted and square the result: prod(x*2) over a 2x3 tensor gave 2**24
+    instead of 2**6. `scalar=6.0` is the case where the constant equals the
+    combined factor exactly.
+    """
+    arr = np.arange(6.0).reshape(2, 3) + 1
+    x = fl_interface.asarray(arr)
+
+    for reduce_fn, np_fn in (
+        (fl_interface.sum, np.sum),
+        (fl_interface.prod, np.prod),
+    ):
+        for expr, np_expr in (
+            (fl_interface.lazy(x) * scalar, arr * scalar),
+            (fl_interface.lazy(x) + scalar, arr + scalar),
+        ):
+            out = fl_interface.compute(
+                reduce_fn(expr, axis=axis), ctx=INTERPRET_NOTATION_GALLEY
+            )
+            assert np.allclose(np.array(out), np_fn(np_expr, axis=axis))
+
+
+def test_repeat_operator_repeated_scalar_literal():
+    """The same constant twice under one reduction: each occurrence is reduced
+    over, so each takes the combined factor."""
+    arr = np.arange(6.0).reshape(2, 3) + 1
+    x = fl_interface.lazy(fl_interface.asarray(arr))
+
+    out = fl_interface.compute(
+        fl_interface.prod(x * 2.0 * 2.0), ctx=INTERPRET_NOTATION_GALLEY
+    )
+    assert np.allclose(np.array(out), (arr * 2.0 * 2.0).prod())
+
+    out = fl_interface.compute(
+        fl_interface.sum(x + 2.0 + 2.0), ctx=INTERPRET_NOTATION_GALLEY
+    )
+    assert np.allclose(np.array(out), (arr + 2.0 + 2.0).sum())
+
+
+def test_repeat_operator_scalar_outside_reduction():
+    """
+    A constant appearing both inside and outside the reduction: the two
+    occurrences are structurally equal, but only the inner one is reduced
+    over. Galley's rewrites address occurrences by path, so the repeat factor
+    applies to the inner occurrence only.
+    """
+    arr = np.arange(6.0).reshape(2, 3) + 1
+    x = fl_interface.lazy(fl_interface.asarray(arr))
+
+    out = fl_interface.compute(
+        fl_interface.prod(x * 2.0) * 2.0, ctx=INTERPRET_NOTATION_GALLEY
+    )
+    assert np.allclose(np.array(out), (arr * 2.0).prod() * 2.0)
+
+    out = fl_interface.compute(
+        fl_interface.sum(x + 2.0) + 2.0, ctx=INTERPRET_NOTATION_GALLEY
+    )
+    assert np.allclose(np.array(out), (arr + 2.0).sum() + 2.0)
+
+    out = fl_interface.compute(
+        fl_interface.prod(x * 6.0) * 6.0, ctx=INTERPRET_NOTATION_GALLEY
+    )
+    assert np.allclose(np.array(out), (arr * 6.0).prod() * 6.0)

--- a/src/finch/tests/test_galley_optimizer_pipeline.py
+++ b/src/finch/tests/test_galley_optimizer_pipeline.py
@@ -443,3 +443,47 @@ def test_repeat_operator_scalar_outside_reduction():
         fl_interface.prod(x * 6.0) * 6.0, ctx=INTERPRET_NOTATION_GALLEY
     )
     assert np.allclose(np.array(out), (arr * 6.0).prod() * 6.0)
+
+
+@pytest.mark.parametrize("scalar", [2.0, 3.0, 6.0])
+def test_repeat_operator_under_nested_reduction(scalar):
+    """
+    A constant under two reductions with different operators. The repeat
+    compensation for the outer sum must not reach the constant that the inner
+    prod also reads: applying it up front scaled the constant by |Dom(i)|,
+    giving sum(prod(x + 2*scalar)) instead of sum(prod(x + scalar)).
+    """
+    arr = np.arange(1.0, 7.0).reshape(2, 3)
+    x = fl_interface.lazy(fl_interface.asarray(arr))
+
+    out = fl_interface.compute(
+        fl_interface.sum(fl_interface.prod(x + scalar, axis=1)),
+        ctx=INTERPRET_NOTATION_GALLEY,
+    )
+    assert np.allclose(np.array(out), (arr + scalar).prod(axis=1).sum())
+
+
+def test_repeat_operator_nested_reduction_no_constant():
+    """The same nesting without a constant, as a control."""
+    arr = np.arange(1.0, 7.0).reshape(2, 3)
+    other = np.arange(7.0, 13.0).reshape(2, 3)
+    x = fl_interface.lazy(fl_interface.asarray(arr))
+    y = fl_interface.lazy(fl_interface.asarray(other))
+
+    out = fl_interface.compute(
+        fl_interface.sum(fl_interface.prod(x + y, axis=1)),
+        ctx=INTERPRET_NOTATION_GALLEY,
+    )
+    assert np.allclose(np.array(out), (arr + other).prod(axis=1).sum())
+
+
+def test_repeat_operator_nested_reduction_swapped_ops():
+    """Outer prod over an inner sum, the mirror of the failing case."""
+    arr = np.arange(1.0, 7.0).reshape(2, 3)
+    x = fl_interface.lazy(fl_interface.asarray(arr))
+
+    out = fl_interface.compute(
+        fl_interface.prod(fl_interface.sum(x + 2.0, axis=1)),
+        ctx=INTERPRET_NOTATION_GALLEY,
+    )
+    assert np.allclose(np.array(out), (arr + 2.0).sum(axis=1).prod())

--- a/src/finch/tests/test_logic_interpreter.py
+++ b/src/finch/tests/test_logic_interpreter.py
@@ -18,8 +18,10 @@ from finch.finch_logic import (
     Plan,
     Produces,
     Query,
+    Relabel,
     Reorder,
     Table,
+    TableValue,
 )
 
 from .conftest import finch_assert_equal
@@ -155,3 +157,23 @@ def test_materialize():
 
     assert (result.to_numpy() == expected.to_numpy()).all()
     finch_assert_equal(C, ft.asarray(np.array([[1, 1], [1, 1]])))
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        Literal(6.0),
+        Reorder(Literal(6.0), ()),
+        Relabel(Literal(6.0), ()),
+        Aggregate(Literal(ffuncs.add), Literal(0.0), Literal(6.0), ()),
+        MapJoin(Literal(ffuncs.add), (Literal(2.0), Literal(4.0))),
+    ],
+    ids=["literal", "reorder", "relabel", "aggregate", "mapjoin"],
+)
+def test_bare_literal_is_zero_dimensional(node):
+    """A bare Literal evaluates to a rank-0 TableValue, so every node type can
+    consume it without special-casing raw scalars."""
+    result = LogicInterpreter()(node)
+    assert isinstance(result, TableValue)
+    assert result.idxs == ()
+    assert float(np.asarray(result.tns)) == 6.0


### PR DESCRIPTION
This PR does a couple of things.
1) It makes Literals LogicExpressions in FinchLogic. This allows them to be used as arguments to Aggregates and MapJoins without wrapping them in Scalars. In a later PR, this will allow us to use them during simplification passes because they are semantically code not data. It also means that they can be compiled to ntn.Literal nodes.
- see: finch_logic/nodes.py, autoschedule/compiler.py
2) It updates the stats interpreter, insert_stats function, finchlogic interpreter, and finchlogic compiler to handle literals properly. 
- see: stats_interpreter.py, logic_to_stats.py, finchlogic/interpreter.py, and autoscheduler/compile.py 
3) It fixes several bugs in AnnotatedQuery by switching from node-based rewrites on the point_expr to path-based rewrites. The bugs were due to the deletion/replacement of nodes in different parts of the expression tree. This was surfaced by the addition of literals which are more likely to be erroneously matched on. In addition, it moves the handling of "repeat operators" (e.g. \sum_i c where c is a scalar) to be lazier.
- see: autoschedule/galley/logic_optimizer/annotated_query.py