### PR TITLE
Lowering Fixes (int types, incomplete lowering, DefaultPass fix)

### DIFF
--- a/src/finch/compile/lower.py
+++ b/src/finch/compile/lower.py
@@ -179,7 +179,7 @@ class SymbolicExtent(FTyped):
                 raise Exception(node)
 
     def get_unit(self):
-        return ntn.Literal(np.intp(1))
+        return ntn.Literal(self.end_sym.result_type(1))
 
     def get_start(self):
         return self.start_sym
@@ -189,9 +189,8 @@ class SymbolicExtent(FTyped):
 
     @staticmethod
     def point(idx):
-        return SymbolicExtent(
-            idx, ntn.Call(ntn.Literal(ffuncs.add), (idx, ntn.Literal(np.intp(1))))
-        )
+        one = ntn.Literal(idx.result_type(1))
+        return SymbolicExtent(idx, ntn.Call(ntn.Literal(ffuncs.add), (idx, one)))
 
     # TODO: Make it more robust
     def is_sym_point(self):
@@ -272,18 +271,17 @@ class ExtentFType(ImmutableStructFType):
                         )
             return
 
-        map(assert_lowered, PostOrderDFS(body))
+        for node in PostOrderDFS(body):
+            assert_lowered(node)
 
-        idx = asm.Variable(ctx.freshen(idx.name), idx.result_type)
         ctx_2 = ctx.scope()
-        ctx_2.bindings[idx.name] = idx
         ctx_2(body)
         body_3 = asm.Block(ctx_2.emit())
         ctx.exec(
             asm.ForLoop(
-                idx,
-                ext.get_start(),
-                ext.get_end(),
+                ctx(idx),
+                ctx(ext.get_start()),
+                ctx(ext.get_end()),
                 body_3,
             )
         )
@@ -723,11 +721,11 @@ class DefaultPass(LoopletPass):
     def priority(self):
         return float("-inf")
 
-    def __call__(self, ctx, idx, ext, body):
+    def __call__(self, ctx: "LoopletContext", idx, ext: SymbolicExtent, body):
         """
         Default pass that does nothing. This is used when no other pass is selected.
         """
-        ext.result_type.default_loop(ctx, idx, ext, body)
+        ext.ftype.default_loop(ctx.ctx, idx, ext, body)
 
 
 class LoopletContext(Context):

--- a/src/finch/tensor/level/dense_level.py
+++ b/src/finch/tensor/level/dense_level.py
@@ -238,9 +238,10 @@ class DenseLevel(Level):
 
     @property
     def stride(self) -> np.integer:
+        dim_t = ftype(self.dimension)
         if self.lvl.ndim == 0 or self.lvl.stride == 0:
-            return np.intp(1)
-        return self.lvl.shape[0] * self.lvl.stride
+            return dim_t(1)
+        return dim_t(self.lvl.shape[0] * self.lvl.stride)
 
     @property
     def ftype(self) -> DenseLevelFType:

--- a/src/finch/tensor/level/sparse_list_level.py
+++ b/src/finch/tensor/level/sparse_list_level.py
@@ -164,7 +164,7 @@ class SparseListLevelFType(LevelFType, ImmutableStructFType):
         resize(lvl_idx, qos_stop)
         """
 
-        ctx.exec(parse_assembly(expr, locals()))
+        ctx.exec(parse_assembly(expr, locals(), position_type=p_t))
         return self.lvl_t.level_lower_freeze(
             ctx, asm.GetAttr(lvl, asm.Literal("lvl")), op, pos
         )
@@ -211,7 +211,7 @@ class SparseListLevelFType(LevelFType, ImmutableStructFType):
                 i_last = 0
             end
             """
-            return parse_assembly(expr, tmp_locals)
+            return parse_assembly(expr, tmp_locals, position_type=self.position_type)
 
         def seek_fn(ctx, ext):
             start = ctx.ctx(ext.get_start())
@@ -222,7 +222,11 @@ class SparseListLevelFType(LevelFType, ImmutableStructFType):
             end
             """
 
-            return parse_assembly(code, tmp_locals | asm.get_vars_in_expr(start))
+            return parse_assembly(
+                code,
+                tmp_locals | asm.get_vars_in_expr(start),
+                position_type=self.position_type,
+            )
 
         def chunk_tail_fn(ctx, idx):
             pos_2 = asm.Variable(
@@ -313,7 +317,9 @@ class SparseListLevel(Level):
 
     @property
     def stride(self) -> np.integer:
-        return np.intp(0)
+        # `stride` is a struct field of type `dimension_type`, so it must be
+        # returned with that exact type rather than the default `intp`.
+        return ftype(self.dimension)(0)
 
     @property
     def ftype(self) -> SparseListLevelFType:

--- a/src/finch/tests/test_issues.py
+++ b/src/finch/tests/test_issues.py
@@ -1,8 +1,10 @@
 import pytest
 
 import numpy as np
+import scipy.sparse as sps
 
 import finch
+from finch.tensor import FiberTensor
 
 
 @pytest.mark.usefixtures("interpreter_scheduler")  # TODO: remove
@@ -26,3 +28,32 @@ def test_issue_50():
     # n = finch.lazy(np.array([[2, 2, 2, 2], [2, 2, 2, 2]]))
     o = finch.lazy(np.array([[3, 3, 3, 3], [3, 3, 3, 3]]))
     finch.add(finch.add(finch.subtract(x, m), n), o)
+
+
+@pytest.mark.parametrize(
+    ("shapes", "density"),
+    [
+        ((2, 2, 2, 2), 0.01),  # the exact repro from the issue: all-empty matrices
+        ((2, 2, 2, 2), 0.9),
+        ((8, 5, 7, 6), 0.4),
+        ((20, 30, 25, 15), 0.15),
+    ],
+)
+@pytest.mark.usefixtures("numba_compiler")
+def test_issue_620(rng, shapes, density):
+    """Chained matmul over scipy CSR inputs, whose indices are int32."""
+    n, m, k, ell = shapes
+    a, b, c = (
+        sps.random(i, j, density=density, format="csr", random_state=rng)
+        for i, j in ((n, m), (m, k), (k, ell))
+    )
+    a_f, b_f, c_f = (FiberTensor.from_scipy_csr(x) for x in (a, b, c))
+
+    result = finch.compute(
+        finch.matmul(
+            finch.matmul(finch.lazy(a_f), finch.lazy(b_f)),
+            finch.lazy(c_f),
+        )
+    )
+
+    np.testing.assert_allclose(np.asarray(result), (a @ b @ c).toarray())


### PR DESCRIPTION
This is a small PR to fix issue #620 . There were just a few bugs in the handling of integer types which were surfaced by the int32 type used in scipy csr. Plus, the DefaultPass was broken (i.e. the pass which inserts a raw loop over the indices).
