### PR TITLE
Add bellman-ford benchmark and keyword support for fused finch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run Julia benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          mode: simulation,memory
+          mode: walltime
           run: |
             pixi run benchmark-julia -vvv -m "not slow"
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,27 @@ jobs:
           run: |
             pixi run benchmark -vvv -m "not slow"
 
+  benchmark-julia:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # required for actions/checkout
+      id-token: write # required for OIDC authentication with CodSpeed
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          pixi-version: v0.71.3
+          environments: benchmark-julia
+      - name: Run Julia benchmarks
+        uses: CodSpeedHQ/action@v4
+        with:
+          mode: simulation,memory
+          run: |
+            pixi run benchmark-julia -vvv -m "not slow"
+
 on:
   push:
     branches:

--- a/benchmarks/test_julia_bellman_ford.py
+++ b/benchmarks/test_julia_bellman_ford.py
@@ -1,6 +1,5 @@
 """
-Julia backend CodSpeed benchmark: Bellman-Ford shortest paths kernel with
-auto active-set semiring relaxation.
+Julia backend CodSpeed benchmark: Bellman-Ford shortest paths kernel.
 
 Run: ``pixi run --environment=benchmark-julia pytest --codspeed
 benchmarks/test_julia_bellman_ford.py``

--- a/benchmarks/test_julia_bellman_ford.py
+++ b/benchmarks/test_julia_bellman_ford.py
@@ -1,0 +1,59 @@
+"""
+Julia backend CodSpeed benchmark: Bellman-Ford shortest paths kernel with
+auto active-set semiring relaxation.
+
+Run: ``pixi run --environment=benchmark-julia pytest --codspeed
+benchmarks/test_julia_bellman_ford.py``
+"""
+
+from pathlib import Path
+
+import pytest
+
+import numpy as np
+import scipy.io
+
+import finch as ft
+from finch.autoschedule import COMPILE_JULIA, with_default_scheduler
+from finch.compile_jl.julia import julia_available
+
+try:
+    import ssgetpy
+except ImportError:
+    ssgetpy = None
+
+pytestmark = pytest.mark.skipif(
+    not julia_available() or ssgetpy is None,
+    reason="Julia backend (juliacall/juliapkg) or ssgetpy not installed",
+)
+
+
+@ft.jit
+def bellman_ford(G, D, max_iter, xp):
+    t = 0
+    while t < max_iter:
+        D = xp.min(xp.expand_dims(D, 1) + G, axis=0)
+        t += 1
+    return D
+
+
+@pytest.fixture(scope="session")
+def bcsstk15_graph():
+    matrix_info = ssgetpy.search(name="bcsstk15")[0]
+    localdestpath, _ = matrix_info.download(format="MM", extract=True)
+    mtx_path = Path(localdestpath) / "bcsstk15.mtx"
+    matrix = scipy.io.mmread(mtx_path).tocsr()
+    return ft.asarray(matrix), matrix.shape[0]
+
+
+def test_julia_bellman_ford(bcsstk15_graph, benchmark):
+    G, n = bcsstk15_graph
+    d = np.full(n, np.inf)
+    d[0] = 0.0
+    D = ft.asarray(d)
+
+    with with_default_scheduler(COMPILE_JULIA):
+        # We know this converges in 39 iterations on this graph
+        bellman_ford(G, D, 40, ft)
+
+        benchmark(bellman_ford, G, D, 40, ft)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,4 +19,3 @@ plugins:
           inventories:
             - https://docs.python.org/3/objects.inv
             - https://numpy.org/doc/stable/objects.inv
-            - http://docs.scipy.org/doc/scipy/reference/objects.inv

--- a/pixi.lock
+++ b/pixi.lock
@@ -2795,7 +2795,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda_source: finch-tensor[4b4b4067] @ .
       - pypi: https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-manylinux_2_34_x86_64.whl
+      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-manylinux_2_34_x86_64.whl
       p2:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_10.conda
@@ -2839,7 +2839,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda_source: finch-tensor[d5485ed8] @ .
       - pypi: https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-manylinux_2_34_aarch64.whl
+      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-manylinux_2_34_aarch64.whl
       p4:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
@@ -2878,7 +2878,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - conda_source: finch-tensor[83bf0017] @ .
       - pypi: https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-macosx_13_0_arm64.whl
+      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-macosx_13_0_arm64.whl
       p5:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
@@ -2921,7 +2921,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - conda_source: finch-tensor[5e62efe6] @ .
       - pypi: https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl
-      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-win_amd64.whl
+      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-win_amd64.whl
   pre-commit:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -4376,7 +4376,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl
-      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-manylinux_2_34_x86_64.whl
+      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-manylinux_2_34_x86_64.whl
       p2:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_10.conda
@@ -4451,7 +4451,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl
-      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-manylinux_2_34_aarch64.whl
+      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-manylinux_2_34_aarch64.whl
       p4:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
@@ -4521,7 +4521,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl
-      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-macosx_13_0_arm64.whl
+      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-macosx_13_0_arm64.whl
       p5:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
@@ -4596,7 +4596,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl
-      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-win_amd64.whl
+      - pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-win_amd64.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -13552,9 +13552,9 @@ packages:
   requires_dist:
   - numpy ; extra == 'arrays'
   requires_python: '>=3.9'
-- pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-macosx_13_0_arm64.whl
+- pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-macosx_13_0_arm64.whl
   name: mlir-python-bindings
-  version: 20260804+eb50d8775
+  version: 20260903+cdb181580
   index: https://llvm.github.io/eudsl
   requires_dist:
   - numpy>=1.19.5
@@ -13562,9 +13562,9 @@ packages:
   - ml-dtypes>=0.1.0,<=0.6.0 ; python_full_version < '3.13'
   - ml-dtypes>=0.5.0,<=0.6.0 ; python_full_version >= '3.13'
   requires_python: '>=3.8'
-- pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-manylinux_2_34_aarch64.whl
+- pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-manylinux_2_34_aarch64.whl
   name: mlir-python-bindings
-  version: 20260804+eb50d8775
+  version: 20260903+cdb181580
   index: https://llvm.github.io/eudsl
   requires_dist:
   - numpy>=1.19.5
@@ -13572,9 +13572,9 @@ packages:
   - ml-dtypes>=0.1.0,<=0.6.0 ; python_full_version < '3.13'
   - ml-dtypes>=0.5.0,<=0.6.0 ; python_full_version >= '3.13'
   requires_python: '>=3.8'
-- pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-manylinux_2_34_x86_64.whl
+- pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-manylinux_2_34_x86_64.whl
   name: mlir-python-bindings
-  version: 20260804+eb50d8775
+  version: 20260903+cdb181580
   index: https://llvm.github.io/eudsl
   requires_dist:
   - numpy>=1.19.5
@@ -13582,9 +13582,9 @@ packages:
   - ml-dtypes>=0.1.0,<=0.6.0 ; python_full_version < '3.13'
   - ml-dtypes>=0.5.0,<=0.6.0 ; python_full_version >= '3.13'
   requires_python: '>=3.8'
-- pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260804+eb50d8775-cp312-cp312-win_amd64.whl
+- pypi: https://github.com/llvm/eudsl/releases/download/mlir-python-bindings/mlir_python_bindings-20260903+cdb181580-cp312-cp312-win_amd64.whl
   name: mlir-python-bindings
-  version: 20260804+eb50d8775
+  version: 20260903+cdb181580
   index: https://llvm.github.io/eudsl
   requires_dist:
   - numpy>=1.19.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ depends-on = [{task = "compile", environment = "benchmark"}]
 default-environment = "benchmark"
 
 [tool.pixi.feature.julia.tasks.benchmark-julia]
-cmd = "pytest --codspeed benchmarks/test_julia_boeing.py"
+cmd = "pytest --codspeed benchmarks/test_julia_boeing.py benchmarks/test_julia_bellman_ford.py"
 depends-on = [{task = "compile", environment = "benchmark-julia"}]
 default-environment = "benchmark-julia"
 

--- a/src/finch/compile_jl/types.py
+++ b/src/finch/compile_jl/types.py
@@ -1,3 +1,4 @@
+import math
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from typing import Any
@@ -178,6 +179,11 @@ def _julia_literal(value: Any) -> str:
     # above), so `isinstance` must use `_py_bool` (captured before shadowing).
     if isinstance(value, (_py_bool, np.bool_)):
         return "true" if value else "false"
+    if isinstance(value, (float, np.floating)):
+        if math.isinf(value):
+            return "-Inf" if value < 0 else "Inf"
+        if math.isnan(value):
+            return "NaN"
     return str(value)
 
 

--- a/src/finch/finch_fused/nodes.py
+++ b/src/finch/finch_fused/nodes.py
@@ -92,21 +92,55 @@ class Variable(FusedExpression, NamedTerm):
 
 
 @dataclass(eq=True, frozen=True)
-class Call(FusedTree, FusedExpression):
-    fn: FusedExpression
-    args: tuple[FusedExpression, ...]
+class Keyword(FusedTree, FusedNode):
+    arg: str
+    value: FusedExpression
 
     @property
     def children(self):
-        return [self.fn, *self.args]
+        return [Literal(self.arg), self.value]
 
     @classmethod
-    def from_children(cls, fn, *args):
-        return cls(fn, tuple(args))
+    def from_children(cls, arg, value):
+        match arg:
+            case Literal(val=name):
+                return cls(name, value)
+            case str(name):
+                return cls(name, value)
+            case _:
+                return cls(str(arg), value)
+
+    @property
+    def result_type(self):
+        return self.value.result_type
+
+
+@dataclass(eq=True, frozen=True)
+class Call(FusedTree, FusedExpression):
+    fn: FusedExpression
+    args: tuple[FusedExpression, ...] = ()
+    kwargs: tuple[Keyword, ...] = ()
+
+    @property
+    def children(self):
+        return [self.fn, *self.args, *self.kwargs]
+
+    @classmethod
+    def from_children(cls, fn, *args_and_kwargs):
+        args: list[FusedExpression] = []
+        kwargs: list[Keyword] = []
+        for child in args_and_kwargs:
+            match child:
+                case Keyword():
+                    kwargs.append(child)
+                case _:
+                    args.append(child)
+        return cls(fn, tuple(args), tuple(kwargs))
 
     @property
     def result_type(self):
         arg_types = [arg.result_type for arg in self.args]
+        arg_types.extend(kw.value.result_type for kw in self.kwargs)
         if isinstance(self.fn, Literal):
             return return_type(self.fn.val, *arg_types)
         return None
@@ -298,12 +332,15 @@ class FusedPrinterContext(Context):
                 return qual_str(value).replace("\n", "")
             case Variable(name, _):
                 return name
-            case Call(fn, args):
+            case Call(fn, args, kwargs):
                 if isinstance(fn, Literal) and fn.val is tuple:
                     if len(args) == 1:
                         return f"({self(args[0])},)"
                     return f"({', '.join(self(arg) for arg in args)})"
-                return f"{self(fn)}({', '.join(self(arg) for arg in args)})"
+                all_args = [self(arg) for arg in args] + [self(kw) for kw in kwargs]
+                return f"{self(fn)}({', '.join(all_args)})"
+            case Keyword(arg, value):
+                return f"{arg}={self(value)}"
             case Compare(left, op, right):
                 return f"({self(left)} {self(op)} {self(right)})"
             case BinaryOp(left, op, right):

--- a/src/finch/finch_fused/parser.py
+++ b/src/finch/finch_fused/parser.py
@@ -146,10 +146,11 @@ class _FusedFunctionParser:
                 return fzd.Literal(value)
             case ast.Name(id=name):
                 return self._parse_name(name)
-            case ast.Call(func=func, args=args, keywords=[]):
+            case ast.Call(func=func, args=args, keywords=keywords):
                 return fzd.Call(
                     self._parse_expr(func),
                     tuple(self._parse_expr(arg) for arg in args),
+                    tuple(self._parse_keyword(kw) for kw in keywords),
                 )
             case ast.BinOp(left=left, op=op, right=right):
                 return fzd.BinaryOp(
@@ -239,6 +240,13 @@ class _FusedFunctionParser:
         for value in values[1:]:
             expr = fzd.BinaryOp(expr, op_lit, self._parse_expr(value))
         return expr
+
+    def _parse_keyword(self, kw: ast.keyword) -> fzd.Keyword:
+        match kw.arg:
+            case None:
+                raise self._unsupported(kw, "Unsupported **kwargs unpacking in call")
+            case str(name):
+                return fzd.Keyword(name, self._parse_expr(kw.value))
 
     def _unsupported(self, node: ast.AST, message: str) -> ValueError:
         lineno = getattr(node, "lineno", "?")
@@ -382,7 +390,7 @@ class _FusedToPythonAST:
                 return ast.Name(id=name, ctx=ast.Load())
             case fzd.Literal(val=value):
                 return self._literal_to_expr(value)
-            case fzd.Call(fn=fn, args=args):
+            case fzd.Call(fn=fn, args=args, kwargs=kwargs):
                 if isinstance(fn, fzd.Literal) and fn.val is tuple:
                     return ast.Tuple(
                         elts=[self._expr_to_ast(arg) for arg in args],
@@ -391,7 +399,10 @@ class _FusedToPythonAST:
                 return ast.Call(
                     func=self._expr_to_ast(fn),
                     args=[self._expr_to_ast(arg) for arg in args],
-                    keywords=[],
+                    keywords=[
+                        ast.keyword(arg=kw.arg, value=self._expr_to_ast(kw.value))
+                        for kw in kwargs
+                    ],
                 )
             case fzd.Compare(left=left, op=fzd.Literal(val=op_fn), right=right):
                 cmp_op = _REV_CMP_OPS.get(op_fn)

--- a/src/finch/tests/test_fused.py
+++ b/src/finch/tests/test_fused.py
@@ -8,6 +8,7 @@ import pytest
 import numpy as np
 
 import finch
+from finch.algebra import ffuncs
 from finch.finch_fused import jit
 from finch.finch_fused import nodes as fzd
 from finch.finch_fused.cfg_builder import (
@@ -30,7 +31,7 @@ def test_parse_simple_function_with_control_flow_and_calls():
         total = 0
         for i in range(n):
             if i < n:  # noqa: SIM108
-                total = fn(total, i)
+                total = fn(total, i, scale=2)
             else:
                 total = total - 1
         while total < n:
@@ -65,6 +66,12 @@ def test_parse_simple_function_with_control_flow_and_calls():
                                                 (
                                                     fzd.Variable("total"),
                                                     fzd.Variable("i"),
+                                                ),
+                                                (
+                                                    fzd.Keyword(
+                                                        "scale",
+                                                        fzd.Literal(2),
+                                                    ),
                                                 ),
                                             ),
                                         ),

--- a/src/finch/tests/test_fused.py
+++ b/src/finch/tests/test_fused.py
@@ -8,7 +8,6 @@ import pytest
 import numpy as np
 
 import finch
-from finch.algebra import ffuncs
 from finch.finch_fused import jit
 from finch.finch_fused import nodes as fzd
 from finch.finch_fused.cfg_builder import (


### PR DESCRIPTION
This PR adds bellman-ford as a benchmark program for the julia backend so that we can track improvements and regressions associated with finch kernel calls within loops. Additionally, the PR extends the fused framework to support keyword arguments within function calls (CC - @kylebd99)