### PR TITLE
Avoid copies in interop

### DIFF
--- a/src/finch/compile_jl/buffer.py
+++ b/src/finch/compile_jl/buffer.py
@@ -15,6 +15,40 @@ class PlusOneBufferFType(BufferFType):
     def __call__(self, *args, **kwargs):
         return PlusOneBuffer(self.data_ftype(*args, **kwargs))
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, PlusOneBufferFType)
+            and self.data_ftype == other.data_ftype
+        )
+
+    def __hash__(self):
+        return hash((PlusOneBufferFType, self.data_ftype))
+
+    @property
+    def element_type(self):
+        return self.data_ftype.element_type
+
+    @property
+    def length_type(self):
+        return self.data_ftype.length_type
+
+
+class MinusOneBufferFType(BufferFType):
+    def __init__(self, data_ftype):
+        self.data_ftype = data_ftype
+
+    def __call__(self, *args, **kwargs):
+        return MinusOneBuffer(self.data_ftype(*args, **kwargs))
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, MinusOneBufferFType)
+            and self.data_ftype == other.data_ftype
+        )
+
+    def __hash__(self):
+        return hash((MinusOneBufferFType, self.data_ftype))
+
     @property
     def element_type(self):
         return self.data_ftype.element_type
@@ -33,8 +67,9 @@ class PlusOneBuffer(Buffer, ABC):
     def __init__(self, data):
         self.data: Buffer = data
 
+    @property
     def ftype(self):
-        return PlusOneBufferFType(self.data.ftype())
+        return PlusOneBufferFType(self.data.ftype)
 
     def length(self):
         return self.data.length()
@@ -49,7 +84,7 @@ class PlusOneBuffer(Buffer, ABC):
 
     @property
     def length_type(self):
-        return self.data.length_type()
+        return self.data.length_type
 
     def load(self, idx: int):
         return self.data.load(idx) + 1
@@ -61,9 +96,49 @@ class PlusOneBuffer(Buffer, ABC):
         self.data.resize(len)
 
 
+class MinusOneBuffer(Buffer, ABC):
+    """
+    Buffer that subtracts one from each element when loaded and adds one to each
+    element when stored.
+    """
+
+    def __init__(self, data):
+        self.data: Buffer = data
+
+    @property
+    def ftype(self):
+        return MinusOneBufferFType(self.data.ftype)
+
+    def length(self):
+        return self.data.length()
+
+    @property
+    def element_type(self):
+        """
+        Return the type of elements stored in the buffer.
+        This is typically the same as the dtype used to create the buffer.
+        """
+        return self.data.element_type
+
+    @property
+    def length_type(self):
+        return self.data.length_type
+
+    def load(self, idx: int):
+        return self.data.load(idx) - 1
+
+    def store(self, idx: int, val):
+        self.data.store(idx, val + 1)
+
+    def resize(self, len: int):
+        self.data.resize(len)
+
+
 def buffer_to_jlobj(buffer: Buffer):
     if isinstance(buffer, PlusOneBuffer):
         return jl.PlusOneVector(buffer_to_jlobj(buffer.data))
+    if isinstance(buffer, MinusOneBuffer):
+        return buffer_to_jlobj(buffer.data)
     if isinstance(buffer, NumpyBuffer):
         return buffer.arr
     raise ValueError(f"Unsupported buffer type: {type(buffer)}")

--- a/src/finch/compile_jl/interop.py
+++ b/src/finch/compile_jl/interop.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import weakref
+from contextlib import suppress
 from typing import Any, cast
 
 import numpy as np
@@ -23,7 +25,72 @@ from finch.tensor import (
 from finch.tensor.np_wrapper import NumPyWrapper
 
 from . import types as jl_dtypes
+from .buffer import MinusOneBuffer
 from .julia import jc, jl
+
+_OBJECT_OWNERS: dict[int, tuple[Any, ...]] = {}
+_EXPORTED_BUFFER_OWNERS: dict[int, tuple[Any, ...]] = {}
+
+
+def _owners(*owners: Any) -> tuple[Any, ...]:
+    return tuple(owner for owner in owners if owner is not None)
+
+
+def _forget_owner(
+    key: int | None,
+    pointers: tuple[int, ...],
+    owners: tuple[Any, ...],
+) -> None:
+    if key is not None:
+        _OBJECT_OWNERS.pop(key, None)
+    for pointer in pointers:
+        if _EXPORTED_BUFFER_OWNERS.get(pointer) is owners:
+            _EXPORTED_BUFFER_OWNERS.pop(pointer, None)
+
+
+def _track_python_owner(
+    jl_obj: Any,
+    *owners: Any,
+    pointers: tuple[int, ...] = (),
+) -> Any:
+    owner_tuple = _owners(*owners)
+    if not owner_tuple:
+        return jl_obj
+
+    pointer_tuple = tuple(int(pointer) for pointer in pointers)
+    for pointer in pointer_tuple:
+        _EXPORTED_BUFFER_OWNERS[pointer] = owner_tuple
+
+    key = None
+    try:
+        jl_obj._finch_python_owners = owner_tuple
+    except (AttributeError, TypeError):
+        key = id(jl_obj)
+        _OBJECT_OWNERS[key] = owner_tuple
+
+    with suppress(TypeError):
+        weakref.finalize(jl_obj, _forget_owner, key, pointer_tuple, owner_tuple)
+    return jl_obj
+
+
+def _exported_python_owner(pointer: int) -> tuple[Any, ...] | None:
+    return _EXPORTED_BUFFER_OWNERS.get(int(pointer))
+
+
+def _track_python_buffer_owner(buffer: NumpyBuffer, *owners: Any) -> NumpyBuffer:
+    owner_tuple = _owners(*owners)
+    if not owner_tuple:
+        return buffer
+
+    key = id(buffer)
+    _OBJECT_OWNERS[key] = owner_tuple
+    with suppress(TypeError):
+        weakref.finalize(buffer, _OBJECT_OWNERS.pop, key, None)
+    return buffer
+
+
+def _python_buffer_owner(buffer: NumpyBuffer) -> tuple[Any, ...] | None:
+    return _OBJECT_OWNERS.get(id(buffer))
 
 
 def is_julia_obj(obj: Any) -> bool:
@@ -37,16 +104,23 @@ def _as_julia_scalar(val):
 
 
 def _buffer_to_jl(buffer: Buffer, *, offset: int = 0):
+    if isinstance(buffer, MinusOneBuffer):
+        if offset != 1:
+            raise ValueError("MinusOneBuffer can only be unwrapped with offset=1")
+        return _buffer_to_jl(buffer.data)
     if isinstance(buffer, NumpyBuffer):
         return jl_dtypes.to_jl_vector(
             buffer.ftype.element_type,
             buffer.arr,
             offset=offset,
+            owner_tracker=_track_python_owner,
         )
     raise ValueError(f"Unsupported buffer type: {type(buffer)}")
 
 
 def _plus_one_buffer_to_jl(buffer: Buffer):
+    if isinstance(buffer, MinusOneBuffer):
+        return _buffer_to_jl(buffer.data)
     return jl.Finch.PlusOneVector(_buffer_to_jl(buffer))
 
 
@@ -133,28 +207,35 @@ def level_to_jl(level: Level, pin_fill: bool = False):
             raise ValueError(f"Unsupported Finch level type: {type(level)}")
 
 
-def _jl_index_buffer_to_python(v) -> NumpyBuffer:
+def _jl_array_to_python(v, *, dtype=None) -> NumpyBuffer:
+    raw = np.asarray(v)
+    if dtype is not None and raw.dtype != np.dtype(dtype):
+        raise ValueError(f"Cannot avoid a copy converting Julia {raw.dtype} to {dtype}")
+    owner = _exported_python_owner(raw.ctypes.data)
+    if owner is not None:
+        return _track_python_buffer_owner(NumpyBuffer(raw), *owner)
+    return _track_python_buffer_owner(NumpyBuffer(raw), v)
+
+
+def _jl_index_buffer_to_python(v) -> Buffer:
     """Converts a Julia index/position buffer, adjusting Julia's 1-based indexing
-    to Python's 0-based indexing, returning an owned copy so Python retains
-    memory ownership across kernel calls."""
+    to Python's 0-based indexing without copying."""
     if jl.isa(v, jl.Finch.PlusOneVector):
-        raw = np.asarray(v.data)
-    else:
-        raw = np.asarray(v)
-        raw -= 1
-    return NumpyBuffer(np.ascontiguousarray(raw).astype(np.intp).copy())
+        return _jl_array_to_python(v.data)
+    return MinusOneBuffer(_jl_array_to_python(v))
 
 
 def _jl_buffer_to_python(v) -> NumpyBuffer:
-    return NumpyBuffer(np.ascontiguousarray(np.asarray(v)).copy())
+    return _jl_array_to_python(v)
 
 
-def _jl_tuple_buffer_to_python(v, n_fields: int, *, offset: int = 0) -> NumpyBuffer:
-    """See _jl_index_buffer_to_python: offset is applied in place, no copy."""
-    raw = np.asarray(v)
-    if offset:
-        for i in range(n_fields):
-            raw[f"f{i}"] -= offset
+def _jl_tuple_buffer_to_python(v, n_fields: int, *, offset: int = 0) -> Buffer:
+    """See _jl_index_buffer_to_python: offset is represented by a wrapper."""
+    if offset not in (0, 1):
+        raise ValueError("Only offset=0 or offset=1 can be represented without a copy")
+
+    raw_buffer = _jl_buffer_to_python(v)
+    raw = raw_buffer.arr
 
     src_fields = raw.dtype.fields
     assert src_fields is not None
@@ -167,20 +248,23 @@ def _jl_tuple_buffer_to_python(v, n_fields: int, *, offset: int = 0) -> NumpyBuf
             "itemsize": raw.dtype.itemsize,
         }
     )
-    return NumpyBuffer(raw.view(dtype))
+    buffer = _track_python_buffer_owner(NumpyBuffer(raw.view(dtype)), raw_buffer)
+    if offset:
+        return MinusOneBuffer(buffer)
+    return buffer
 
 
 def jl_level_to_python(jl_lvl) -> Level:
     if jl.isa(jl_lvl, jl.Finch.ElementLevel):
         fill_value = jl.Finch.level_fill_value(jl.typeof(jl_lvl))
-        val = np.ascontiguousarray(np.asarray(jl_lvl.val)).copy()
+        val = _jl_buffer_to_python(jl_lvl.val)
         elem_ftype = element(
-            jl_dtypes.to_fl_dtype(val.dtype)(fill_value),
-            jl_dtypes.to_fl_dtype(val.dtype),
+            jl_dtypes.to_fl_dtype(val.arr.dtype)(fill_value),
+            jl_dtypes.to_fl_dtype(val.arr.dtype),
             jl_dtypes.int_,
             NumpyBufferFType,
         )
-        return ElementLevel(elem_ftype, NumpyBuffer(val))
+        return ElementLevel(elem_ftype, val)
 
     if jl.isa(jl_lvl, jl.Finch.DenseLevel):
         return DenseLevel(
@@ -249,7 +333,8 @@ def _ndarray_to_jl_tensor(
     lvl = jl.ElementLevel(fill, buf)
     for dim in reversed(arr.shape):
         lvl = jl.DenseLevel(lvl, int(dim))
-    return jl.Tensor(lvl)
+    tensor = jl.Tensor(lvl)
+    return _track_python_owner(tensor, arr, pointers=(arr.ctypes.data,))
 
 
 def tensor_to_jl(obj, pin_fill: bool = False):
@@ -261,7 +346,7 @@ def tensor_to_jl(obj, pin_fill: bool = False):
     if isinstance(obj, FiberTensor):
         if obj.pos != 0:
             raise ValueError("Only root-position FiberTensor objects can use Julia")
-        return jl.Tensor(level_to_jl(obj.lvl, pin_fill))
+        return _track_python_owner(jl.Tensor(level_to_jl(obj.lvl, pin_fill)), obj)
     if isinstance(obj, BufferizedNDArray):
         fill = ftype(obj.fill_value)(0) if pin_fill else obj.fill_value
         return _ndarray_to_jl_tensor(obj.to_numpy(), fill, copy=False)
@@ -286,7 +371,14 @@ def scalar_to_jl(val):
     if isinstance(val, np.generic):
         val = val.item()
     buf = np.asarray([val])
-    return jl.Tensor(jl.ElementLevel(_as_julia_scalar(buf.item()), jl.Vector(buf)))
+    jl_type = jl_dtypes._fl_dtype_to_jl()[ftype(buf.dtype)]
+    tensor = jl.Tensor(
+        jl.ElementLevel(
+            _as_julia_scalar(buf.item()),
+            jl.wrap_numpy_ptr(buf.ctypes.data, buf.size, jl_type),
+        )
+    )
+    return _track_python_owner(tensor, buf, pointers=(buf.ctypes.data,))
 
 
 def jl_tensor_to_python(obj):

--- a/src/finch/compile_jl/types.py
+++ b/src/finch/compile_jl/types.py
@@ -57,16 +57,18 @@ class JuliaElementFType(ABC):
         """
         ...
 
-    def julia_vector(self, values, *, offset: int = 0):
+    def julia_vector(self, values, *, offset: int = 0, owner_tracker=None):
         if not isinstance(values, np.ndarray):
             raise TypeError(f"Expected np.ndarray, got {type(values)}")
-        if offset != 0:
-            values = values + offset
-        if not values.flags["C_CONTIGUOUS"]:
-            values = np.ascontiguousarray(values)
-        return get_jl().wrap_numpy_ptr(
+        if offset != 0 or not values.flags["C_CONTIGUOUS"] or owner_tracker is None:
+            return jc.convert(
+                get_jl().Vector[self.julia_type()],
+                [self.julia_value(value, offset=offset) for value in values],
+            )
+        vec = get_jl().wrap_numpy_ptr(
             values.ctypes.data, values.size, self.julia_type()
         )
+        return owner_tracker(vec, values, pointers=(values.ctypes.data,))
 
 
 @lru_cache
@@ -160,17 +162,27 @@ def to_jl_value(T, value, *, offset: int = 0):
     return _as_julia_scalar(T(value))
 
 
-def to_jl_vector(T, values, *, offset: int = 0):
+def to_jl_vector(T, values, *, offset: int = 0, owner_tracker=None):
     T = to_fl_dtype(T)
     if isinstance(T, JuliaElementFType):
-        return T.julia_vector(values, offset=offset)
+        return T.julia_vector(values, offset=offset, owner_tracker=owner_tracker)
     if isinstance(T, TupleFType) or offset:
         jl = get_jl()
         return jc.convert(
             jl.Vector[to_jl_type(T)],
             [to_jl_value(T, value, offset=offset) for value in values],
         )
-    return get_jl().Vector(values)
+    expected_dtype = getattr(T, "dtype", None)
+    if expected_dtype is not None and np.dtype(values.dtype) != np.dtype(
+        expected_dtype
+    ):
+        raise ValueError(
+            f"Cannot avoid a copy converting {values.dtype} to Julia {to_jl_type(T)}"
+        )
+    if not values.flags["C_CONTIGUOUS"] or owner_tracker is None:
+        return get_jl().Vector(values)
+    vec = get_jl().wrap_numpy_ptr(values.ctypes.data, values.size, to_jl_type(T))
+    return owner_tracker(vec, values, pointers=(values.ctypes.data,))
 
 
 def _julia_literal(value: Any) -> str:
@@ -181,9 +193,9 @@ def _julia_literal(value: Any) -> str:
             value = fill.value
     # NOTE: this module shadows the builtin `bool` (see `bool: FDTypeNumpy`
     # above), so `isinstance` must use `_py_bool` (captured before shadowing).
-    if isinstance(value, (_py_bool, np.bool_)):
+    if isinstance(value, _py_bool | np.bool_):
         return "true" if value else "false"
-    if isinstance(value, (float, np.floating)):
+    if isinstance(value, float | np.floating):
         if math.isinf(value):
             return "-Inf" if value < 0 else "Inf"
         if math.isnan(value):

--- a/src/finch/tests/test_julia_buffer.py
+++ b/src/finch/tests/test_julia_buffer.py
@@ -1,0 +1,170 @@
+import numpy as np
+
+from finch.codegen import NumpyBuffer, NumpyBufferFType
+from finch.compile_jl.buffer import (
+    MinusOneBuffer,
+    MinusOneBufferFType,
+    PlusOneBuffer,
+    PlusOneBufferFType,
+    buffer_to_jlobj,
+)
+from finch.compile_jl.julia import julia_available
+
+
+def _requires_julia_backend():
+    if not julia_available():
+        import pytest
+
+        pytest.skip("the julia extra (juliapkg, juliacall) is not installed")
+
+
+def test_minus_one_buffer_offsets_loads_and_stores():
+    arr = np.array([1, 3, 5], dtype=np.intp)
+    buf = MinusOneBuffer(NumpyBuffer(arr))
+
+    assert buf.load(0) == 0
+    assert buf.load(1) == 2
+
+    buf.store(2, 7)
+
+    assert arr[2] == 8
+
+
+def test_offset_buffers_do_not_expose_materialized_arrays():
+    arr = np.array([1, 3, 5], dtype=np.intp)
+    data = NumpyBuffer(arr)
+
+    assert not hasattr(PlusOneBuffer(data), "arr")
+    assert not hasattr(MinusOneBuffer(data), "arr")
+
+
+def test_offset_buffer_ftypes_forward_to_wrapped_buffer():
+    arr = np.array([0, 1, 2], dtype=np.intp)
+    numpy_buf = NumpyBuffer(arr)
+
+    plus_ftype = PlusOneBuffer(numpy_buf).ftype
+    minus_ftype = MinusOneBuffer(numpy_buf).ftype
+
+    assert isinstance(plus_ftype, PlusOneBufferFType)
+    assert isinstance(minus_ftype, MinusOneBufferFType)
+    assert isinstance(plus_ftype.data_ftype, NumpyBufferFType)
+    assert isinstance(minus_ftype.data_ftype, NumpyBufferFType)
+    assert plus_ftype.element_type == numpy_buf.ftype.element_type
+    assert minus_ftype.element_type == numpy_buf.ftype.element_type
+    assert plus_ftype.length_type == numpy_buf.ftype.length_type
+    assert minus_ftype.length_type == numpy_buf.ftype.length_type
+
+
+def test_minus_one_buffer_to_julia_object_unwraps_data():
+    arr = np.array([1, 2, 3], dtype=np.intp)
+    buf = MinusOneBuffer(NumpyBuffer(arr))
+
+    assert buffer_to_jlobj(buf) is arr
+
+
+def test_plus_one_interop_unwraps_minus_one_buffer(monkeypatch):
+    from finch.compile_jl import interop
+
+    arr = np.array([1, 2, 3], dtype=np.intp)
+    data = NumpyBuffer(arr)
+    buf = MinusOneBuffer(data)
+    converted = object()
+
+    def fake_buffer_to_jl(buffer):
+        assert buffer is data
+        return converted
+
+    monkeypatch.setattr(interop, "_buffer_to_jl", fake_buffer_to_jl)
+
+    assert interop._plus_one_buffer_to_jl(buf) is converted
+
+
+def test_julia_owned_buffer_to_python_is_zero_copy():
+    _requires_julia_backend()
+    from finch.compile_jl.interop import _jl_buffer_to_python, _python_buffer_owner
+    from finch.compile_jl.julia import jl
+
+    jl_vec = jl.Vector[jl.Int]([1, 2, 3])
+    buf = _jl_buffer_to_python(jl_vec)
+
+    assert isinstance(buf, NumpyBuffer)
+    assert _python_buffer_owner(buf) == (jl_vec,)
+
+    buf.store(0, 42)
+
+    assert int(jl_vec[0]) == 42
+
+
+def test_plain_julia_index_buffer_to_python_uses_minus_one_without_mutating():
+    _requires_julia_backend()
+    from finch.compile_jl.interop import _jl_index_buffer_to_python
+    from finch.compile_jl.julia import jl
+
+    jl_vec = jl.Vector[jl.Int]([1, 3, 4])
+    buf = _jl_index_buffer_to_python(jl_vec)
+
+    assert isinstance(buf, MinusOneBuffer)
+    assert buf.load(0) == 0
+    assert buf.load(1) == 2
+    assert [int(v) for v in jl_vec] == [1, 3, 4]
+
+    buf.store(2, 7)
+
+    assert int(jl_vec[2]) == 8
+
+
+def test_plus_one_julia_index_buffer_to_python_unwraps_data_zero_copy():
+    _requires_julia_backend()
+    from finch.compile_jl.interop import _jl_index_buffer_to_python
+    from finch.compile_jl.julia import jl
+
+    raw = jl.Vector[jl.Int]([0, 2, 3])
+    plus_one = jl.Finch.PlusOneVector(raw)
+    buf = _jl_index_buffer_to_python(plus_one)
+
+    assert isinstance(buf, NumpyBuffer)
+    np.testing.assert_array_equal(buf.arr, np.array([0, 2, 3], dtype=np.intp))
+
+    buf.store(1, 5)
+
+    assert int(raw[1]) == 5
+
+
+def test_plus_one_julia_int32_index_buffer_to_python_is_zero_copy():
+    _requires_julia_backend()
+    from finch.compile_jl.interop import _jl_index_buffer_to_python
+    from finch.compile_jl.julia import jl
+
+    raw = jl.Vector[jl.Int32]([0, 2, 3])
+    plus_one = jl.Finch.PlusOneVector(raw)
+    buf = _jl_index_buffer_to_python(plus_one)
+
+    assert isinstance(buf, NumpyBuffer)
+    assert buf.arr.dtype == np.dtype(np.int32)
+    np.testing.assert_array_equal(buf.arr, np.array([0, 2, 3], dtype=np.int32))
+
+    buf.store(1, 5)
+
+    assert int(raw[1]) == 5
+
+
+def test_python_owned_julia_buffer_round_trip_retains_python_owner():
+    _requires_julia_backend()
+    from finch.compile_jl.interop import (
+        _jl_buffer_to_python,
+        _python_buffer_owner,
+        tensor_to_jl,
+    )
+
+    arr = np.array([1, 2, 3], dtype=np.int64)
+    jl_tensor = tensor_to_jl(arr)
+    buf = _jl_buffer_to_python(jl_tensor.lvl.lvl.val)
+
+    owner = _python_buffer_owner(buf)
+    assert owner is not None
+    assert any(item is arr for item in owner)
+    assert buf.arr.ctypes.data == arr.ctypes.data
+
+    buf.store(0, 9)
+
+    assert arr[0] == 9


### PR DESCRIPTION
This is a codex-drafted PR that's on the right track for what we need to do here: We need to keep track of which pointers are python owned and which ones are julia owned. If we pass a pointer to julia and it reallocs the pointer, then the old one is gone and it's a julia-owned pointer.