### PR TITLE
Add local value-numbering analysis for Finch Logic

### DIFF
--- a/src/finch/finch_logic/__init__.py
+++ b/src/finch/finch_logic/__init__.py
@@ -4,6 +4,11 @@ from .interpreter import (
     MockLogicLibrary,
     MockLogicLoader,
 )
+from .local_value_numbering import (
+    LogicDefinition,
+    LogicLocalValueNumberingResult,
+    logic_local_value_numbering,
+)
 from .nodes import (
     Aggregate,
     Alias,
@@ -37,10 +42,12 @@ __all__ = [
     "Alias",
     "Field",
     "Literal",
+    "LogicDefinition",
     "LogicEvaluator",
     "LogicExpression",
     "LogicInterpreter",
     "LogicLoader",
+    "LogicLocalValueNumberingResult",
     "LogicNode",
     "LogicSimplify",
     "LogicStatement",
@@ -61,4 +68,5 @@ __all__ = [
     "TensorStats",
     "Value",
     "compute_shape_vars",
+    "logic_local_value_numbering",
 ]

--- a/src/finch/finch_logic/local_value_numbering.py
+++ b/src/finch/finch_logic/local_value_numbering.py
@@ -1,0 +1,318 @@
+"""Local value-numbering analysis for sequential, aliased Finch Logic plans.
+
+Adapted from the hash-based local value-numbering approach in Steven S. Muchnick,
+Advanced Compiler Design and Implementation (1997), section 12.4.1, pp. 344-348.
+Unlike its Remove routine (Figure 12.14, p. 347), this analysis versions changed
+operands rather than deleting historical expression keys. The table records value
+equivalence, not available replacement candidates. It does not implement the
+textbook's rewrites, commutative matching, or global algorithm in section 12.4.2.
+
+This analysis records values immediately after definitions, not the current
+contents of all tensors ever assigned those values. Equal value numbers do not
+prove that a replacement is available or that two outputs may share storage.
+Branches, loops, reductions and general alias/effect analysis are not supported.
+"""
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from finch.algebra import FType, TensorFType, ffuncs, ftype, return_type
+from finch.symbolic import PostOrderDFS
+
+from .nodes import (
+    Alias,
+    Field,
+    Literal,
+    LogicExpression,
+    LogicStatement,
+    MapJoin,
+    Plan,
+    Produces,
+    Query,
+    Reorder,
+    Table,
+)
+
+_NUMPY_SCALARS = (
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.float16,
+    np.float32,
+    np.float64,
+    np.complex64,
+    np.complex128,
+)
+_SCALARS = (int, float, complex, *_NUMPY_SCALARS)
+_NUMPY_TYPES = tuple(ftype(t) for t in _NUMPY_SCALARS)
+_TYPES = tuple(ftype(t) for t in _SCALARS)
+
+
+@dataclass(frozen=True)
+class LogicDefinition:
+    """An input, query occurrence, or storage invalidation in one analysis run.
+
+    Query IDs are nonnegative and follow execution order. Negative IDs denote
+    inputs or synthetic versions; ``invalidated_by`` identifies the writing query.
+    """
+
+    sid: int
+    alias: Alias
+    query: Query | None = None
+    invalidated_by: int | None = None
+
+
+@dataclass
+class LogicLocalValueNumberingResult:
+    """Definition snapshots and stored-value equivalence within a single plan.
+
+    ``uses`` records query-entry definitions referenced by the RHS. For opaque
+    expressions it does not resolve reads after effects nested inside that RHS.
+    """
+
+    definitions: dict[int, LogicDefinition]
+    uses: dict[int, tuple[int, ...]]
+    value_numbers: dict[int, int]
+    current_definitions: dict[Alias, int]
+
+    @property
+    def equivalence_classes(self) -> dict[int, tuple[int, ...]]:
+        """Group query definitions by their stored value, including singletons."""
+        groups: dict[int, list[int]] = {}
+        for sid, definition in self.definitions.items():
+            if definition.query is not None:
+                vn = self.value_numbers[sid]
+                groups.setdefault(vn, []).append(sid)
+        return {vn: tuple(sids) for vn, sids in groups.items()}
+
+
+@dataclass(frozen=True)
+class _Value:
+    number: int
+    dtype: FType | None
+    ndim: int | None
+    materialized: bool = False
+
+
+@dataclass(frozen=True)
+class _Expression:
+    value: _Value
+    fields: tuple[Field, ...]
+
+
+def _statements(node: LogicStatement) -> Iterator[Query | Produces]:
+    match node:
+        case Plan(bodies):
+            for body in bodies:
+                for stmt in _statements(body):
+                    yield stmt
+                    if isinstance(stmt, Produces):
+                        return
+        case Query() | Produces():
+            yield node
+        case _:
+            raise TypeError(f"Unsupported Logic statement: {type(node).__name__}")
+
+
+class _LogicLocalValueNumbering:
+    def __init__(self, bindings: dict[Alias, TensorFType]):
+        self.result = LogicLocalValueNumberingResult({}, {}, {}, {})
+        self.values: dict[Alias, _Value] = {}
+        self.external = tuple(bindings)
+        self.table: dict[tuple, int] = {}
+        self.next_value = 0
+        self.next_version = -1
+        for alias, tp in bindings.items():
+            dtype: FType | None = tp.element_type
+            dtype = dtype if any(dtype is t for t in _TYPES) else None
+            value = _Value(self.fresh(), dtype, tp.ndim)
+            self.version(alias, value)
+
+    def fresh(self) -> int:
+        number = self.next_value
+        self.next_value += 1
+        return number
+
+    def intern(self, key: tuple) -> int:
+        if key not in self.table:
+            self.table[key] = self.fresh()
+        return self.table[key]
+
+    def record(self, definition: LogicDefinition, value: _Value) -> None:
+        self.result.definitions[definition.sid] = definition
+        self.result.value_numbers[definition.sid] = value.number
+        self.result.current_definitions[definition.alias] = definition.sid
+        self.values[definition.alias] = value
+
+    def version(self, alias: Alias, value: _Value, sid: int | None = None) -> None:
+        definition = LogicDefinition(self.next_version, alias, invalidated_by=sid)
+        self.next_version -= 1
+        self.record(definition, value)
+
+    def invalidate(self, aliases, sid: int, *, unknown_effect: bool = False) -> None:
+        for alias in aliases:
+            old = self.values[alias]
+            value = _Value(
+                self.fresh(),
+                None if unknown_effect else old.dtype,
+                None if unknown_effect else old.ndim,
+            )
+            self.version(alias, value, sid)
+
+    def reads(self, expr) -> tuple[int, ...]:
+        uses = []
+        for node in PostOrderDFS(expr):
+            match node:
+                case Alias():
+                    if node not in self.values:
+                        raise ValueError(f"Undefined tensor alias: {node.name}")
+                    uses.append(self.result.current_definitions[node])
+                case Table(Literal(), _):
+                    raise ValueError("Extract tensor literals before value numbering")
+                case Table(Alias() as alias, fields):
+                    ndim = self.values[alias].ndim
+                    if len(set(fields)) != len(fields):
+                        raise ValueError("Table fields must be distinct")
+                    if ndim is not None and len(fields) != ndim:
+                        raise ValueError(
+                            f"Table rank does not match alias {alias.name}"
+                        )
+        return tuple(uses)
+
+    def expression(self, expr: LogicExpression) -> _Expression | None:
+        match expr:
+            case Table(Alias() as alias, fields):
+                value = self.values[alias]
+                if value.dtype is not None:
+                    return _Expression(value, fields)
+            case Literal(val) if type(val) in _SCALARS:
+                # Literal/StaticFill equality collapses signed zero. Exact scalar
+                # types and bytes also preserve complex signs and NaN payloads.
+                bits: Any = val if type(val) is int else np.asarray(val).tobytes()
+                number = self.intern((Literal, type(val), bits))
+                return _Expression(_Value(number, ftype(val), 0), ())
+            case MapJoin(Literal(op), args) if (
+                any(op is f for f in (ffuncs.add, ffuncs.sub, ffuncs.mul))
+                and len(args) == 2
+            ):
+                operands = [self.expression(arg) for arg in args]
+                if any(arg is None for arg in operands):
+                    return None
+                known = [arg for arg in operands if arg is not None]
+                fields = tuple(dict.fromkeys(f for arg in known for f in arg.fields))
+                if any(arg.fields and set(arg.fields) != set(fields) for arg in known):
+                    return None  # Broadcasting between non-scalar arrays.
+                types = [
+                    arg.value.dtype for arg in known if arg.value.dtype is not None
+                ]
+                if len(types) != len(known):
+                    return None
+                # Only trusted operators on exact, standard numeric types reach
+                # Finch's inference, which evaluates operators on sample scalars.
+                try:
+                    dtype = return_type(op, *types)
+                except (TypeError, ValueError, NotImplementedError):
+                    return None
+                if not any(dtype is t for t in _TYPES):
+                    return None
+                key = (
+                    MapJoin,
+                    op,
+                    tuple(
+                        (arg.value.number, tuple(fields.index(f) for f in arg.fields))
+                        for arg in known
+                    ),
+                    dtype,
+                )
+                return _Expression(_Value(self.intern(key), dtype, len(fields)), fields)
+            case Reorder(arg, fields):
+                inner = self.expression(arg)
+                if inner is None:
+                    return None
+                if len(set(fields)) != len(fields):
+                    raise ValueError("Reorder fields must be distinct")
+                if set(fields) != set(inner.fields):
+                    return None  # Inserting/dropping axes needs extent information.
+                if fields == inner.fields:
+                    return inner
+                permutation = tuple(inner.fields.index(f) for f in fields)
+                number = self.intern((Reorder, inner.value.number, permutation))
+                return _Expression(
+                    _Value(number, inner.value.dtype, len(fields)), fields
+                )
+        return None
+
+    def materialize(self, value: _Value) -> _Value:
+        # Keep the Query boundary: literal and external tensor metadata need not
+        # survive allocation unchanged. Copies of known numeric local results are
+        # idempotent. Operand VNs carry shape/fill provenance without comparing
+        # DynamicFill objects (whose equality intentionally ignores their values).
+        if value.materialized:
+            return value
+        dtype = value.dtype if any(value.dtype is t for t in _NUMPY_TYPES) else None
+        return _Value(self.intern((Query, value.number)), dtype, value.ndim, True)
+
+    def analyze(self, plan: Plan) -> LogicLocalValueNumberingResult:
+        sid = 0
+        for stmt in _statements(plan):
+            match stmt:
+                case Produces():
+                    self.reads(stmt)
+                    break
+                case Query(lhs, rhs):
+                    self.result.uses[sid] = self.reads(rhs)
+                    expr = self.expression(rhs)
+                    old = self.values.get(lhs)
+                    if expr is None:
+                        self.invalidate(tuple(self.values), sid, unknown_effect=True)
+                        value = _Value(self.fresh(), None, None)
+                    else:
+                        value = self.materialize(expr.value)
+                    if lhs in self.external:
+                        self.invalidate(self.external, sid)
+                        value = _Value(
+                            self.fresh(),
+                            old.dtype if old and expr is not None else None,
+                            old.ndim if old and expr is not None else None,
+                        )
+                    elif old is not None and old.number != value.number:
+                        # Equal rank/type is not proof of equal extents or fill.
+                        # Preserve storage metadata only for modeled writes.
+                        value = _Value(
+                            self.fresh(),
+                            old.dtype if expr is not None else None,
+                            old.ndim if expr is not None else None,
+                        )
+                    self.record(LogicDefinition(sid, lhs, stmt), value)
+                    sid += 1
+        return self.result
+
+
+def logic_local_value_numbering(
+    plan: Plan, bindings: dict[Alias, TensorFType]
+) -> LogicLocalValueNumberingResult:
+    """Locally number query definitions and equivalent stored values without rewriting.
+
+    Inputs must be aliased Logic with defined RHS reads. Query IDs start at zero;
+    ``uses[sid]`` lists query-entry definition/version IDs in RHS traversal order,
+    including repeated references. For an opaque RHS, these are not per-read facts
+    across nested effects. IDs and value numbers are local to this invocation.
+
+    Recognizes ordered numeric add/subtract/multiply, scalar literals, copies and
+    rank-preserving reorders. External writes invalidate every external binding;
+    unsupported expressions conservatively invalidate all current tensor facts.
+    Materialization boundaries are retained, so a copy of an external tensor or a
+    literal need not share its source's number. Historical equivalence is not CSE
+    availability, storage identity, or equivalence across separate plan executions.
+    """
+    if not isinstance(plan, Plan):
+        raise TypeError("Value numbering requires a Logic Plan")
+    return _LogicLocalValueNumbering(bindings).analyze(plan)

--- a/src/finch/tests/test_logic_local_value_numbering.py
+++ b/src/finch/tests/test_logic_local_value_numbering.py
@@ -1,0 +1,370 @@
+import pytest
+
+import numpy as np
+
+import finch
+from finch.algebra import DynamicFill, ffuncs, ftype
+from finch.autoschedule.executor import extract_tensors
+from finch.finch_logic import (
+    Aggregate,
+    Alias,
+    Field,
+    Literal,
+    LogicInterpreter,
+    MapJoin,
+    Plan,
+    Produces,
+    Query,
+    Reorder,
+    Table,
+    logic_local_value_numbering,
+)
+from finch.tensor import BufferizedNDArray
+
+A, B, C, D, X, Y, Z = map(Alias, ("A", "B", "C", "D", "X", "Y", "Z"))
+i, j = Field("i"), Field("j")
+
+
+def table(alias, fields=(i,)):
+    return Table(alias, fields)
+
+
+def add(a=A, b=B, fields=(i,)):
+    return MapJoin(Literal(ffuncs.add), (table(a, fields), table(b, fields)))
+
+
+@pytest.fixture
+def bindings():
+    tp = ftype(BufferizedNDArray.from_numpy(np.zeros(3, dtype=np.int64)))
+    return {A: tp, B: tp, C: tp}
+
+
+def analyze(*stmts, bindings):
+    return logic_local_value_numbering(Plan(stmts), bindings)
+
+
+def test_equivalent_definitions_and_copies(bindings):
+    result = analyze(
+        Query(X, add()), Query(Y, table(X)), Query(Z, add()), bindings=bindings
+    )
+    assert result.value_numbers[0] == result.value_numbers[1] == result.value_numbers[2]
+    assert result.equivalence_classes[result.value_numbers[0]] == (0, 1, 2)
+    assert result.uses[1] == (0,)
+    assert result.definitions[0].query.lhs == X
+    assert result.definitions[1].query.lhs == Y
+
+
+def test_number_occurrences_not_node_objects(bindings):
+    stmt = Query(X, add())
+    result = analyze(stmt, Plan((stmt,)), bindings=bindings)
+    assert result.definitions[0].query is result.definitions[1].query
+    assert result.value_numbers[0] == result.value_numbers[1]
+    assert result.current_definitions[X] == 1
+
+
+def test_rhs_reads_precede_redefinition(bindings):
+    result = analyze(
+        Query(X, add()), Query(A, add(A, A)), Query(Y, add()), bindings=bindings
+    )
+    a_input, b_input = result.uses[0]
+    assert a_input < 0 and b_input < 0
+    assert result.uses[1] == (a_input, a_input)
+    assert result.uses[2][0] == 1
+    assert result.uses[2][1] != b_input
+    assert result.value_numbers[0] != result.value_numbers[2]
+    assert result.definitions[result.uses[2][1]].invalidated_by == 1
+
+
+def test_copy_redefinition_kills_equivalence(bindings):
+    result = analyze(
+        Query(X, add()), Query(A, table(C)), Query(Y, add()), bindings=bindings
+    )
+    assert result.value_numbers[0] != result.value_numbers[2]
+
+
+def test_independent_local_write_preserves_equivalence(bindings):
+    result = analyze(
+        Query(D, table(C)),
+        Query(X, add()),
+        Query(D, add(D, D)),
+        Query(Y, add()),
+        bindings=bindings,
+    )
+    assert result.value_numbers[1] == result.value_numbers[3]
+    assert result.value_numbers[0] != result.value_numbers[2]
+
+
+def test_copies_are_independent_snapshots(bindings):
+    result = analyze(
+        Query(X, add()),
+        Query(Y, table(X)),
+        Query(X, table(C)),
+        Query(Z, table(Y)),
+        bindings=bindings,
+    )
+    assert result.value_numbers[0] == result.value_numbers[1] == result.value_numbers[3]
+    assert result.value_numbers[2] != result.value_numbers[3]
+    assert result.uses[3] == (1,)
+
+
+def test_external_writes_version_all_possible_aliases(bindings):
+    result = analyze(
+        Query(X, add()),
+        Query(C, table(A)),
+        Query(Y, add()),
+        Query(C, table(A)),
+        Query(Z, add()),
+        bindings=bindings,
+    )
+    assert len({result.value_numbers[sid] for sid in (0, 2, 4)}) == 3
+    for sid in (0, 2, 4):
+        assert len(set(result.uses[sid])) == 2
+    assert len({result.uses[sid][0] for sid in (0, 2, 4)}) == 3
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_unknown_calls_are_not_executed_and_invalidate_locals(bindings, nested):
+    def unknown():
+        raise AssertionError("The analysis must not execute this operator")
+
+    call = MapJoin(Literal(unknown), ())
+    rhs = MapJoin(Literal(ffuncs.add), (call, table(A))) if nested else call
+    result = analyze(
+        Query(D, table(A)),
+        Query(X, add(D, B)),
+        Query(C, rhs),
+        Query(Y, add(D, B)),
+        bindings=bindings,
+    )
+    assert result.value_numbers[1] != result.value_numbers[3]
+    assert result.uses[3][0] != 0
+    assert result.definitions[result.uses[3][0]].invalidated_by == 2
+
+
+def test_scalar_subclasses_are_opaque():
+    class IntWithEffects(int):
+        def __add__(self, other):
+            raise AssertionError("custom numeric methods must not run")
+
+    expr = MapJoin(Literal(ffuncs.add), (Literal(IntWithEffects(1)), Literal(2)))
+    result = analyze(Query(X, expr), Query(Y, expr), bindings={})
+    assert result.value_numbers[0] != result.value_numbers[1]
+
+
+def test_field_alpha_renaming_and_frontend_reorders(bindings):
+    k = Field("fresh")
+    wrapped = Reorder(
+        MapJoin(Literal(ffuncs.add), (Reorder(table(A, (k,)), (k,)), table(B, (k,)))),
+        (k,),
+    )
+    result = analyze(Query(X, add()), Query(Y, wrapped), bindings=bindings)
+    assert result.value_numbers[0] == result.value_numbers[1]
+
+
+def test_axis_mapping_is_part_of_expression_key():
+    tp = ftype(BufferizedNDArray.from_numpy(np.zeros((2, 2), dtype=np.int64)))
+    expr = add(fields=(i, j))
+    transposed_b = MapJoin(Literal(ffuncs.add), (table(A, (i, j)), table(B, (j, i))))
+    result = analyze(
+        Query(X, expr),
+        Query(Y, transposed_b),
+        Query(Z, Reorder(expr, (j, i))),
+        bindings={A: tp, B: tp},
+    )
+    assert len({result.value_numbers[sid] for sid in (0, 1, 2)}) == 3
+
+
+@pytest.mark.parametrize("op", [ffuncs.sub, ffuncs.mul])
+def test_operator_identity_is_part_of_key(bindings, op):
+    result = analyze(
+        Query(X, add()),
+        Query(Y, MapJoin(Literal(op), (table(A), table(B)))),
+        bindings=bindings,
+    )
+    assert result.value_numbers[0] != result.value_numbers[1]
+
+
+def test_operand_order_is_preserved(bindings):
+    result = analyze(Query(X, add()), Query(Y, add(B, A)), bindings=bindings)
+    assert result.value_numbers[0] != result.value_numbers[1]
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        (1, np.int64(1)),
+        (np.float32(1), np.float64(1)),
+        (0.0, -0.0),
+        (np.float32(0), np.float32(-0.0)),
+        (complex(0.0, 0.0), complex(0.0, -0.0)),
+    ],
+)
+def test_literal_type_and_bits_are_preserved(a, b):
+    result = analyze(Query(X, Literal(a)), Query(Y, Literal(b)), bindings={})
+    assert result.value_numbers[0] != result.value_numbers[1]
+
+
+def test_literal_materialization_has_its_own_value():
+    expr = MapJoin(Literal(ffuncs.add), (Literal(1), Literal(2)))
+    result = analyze(
+        Query(X, Literal(1)),
+        Query(Y, expr),
+        Query(Z, MapJoin(Literal(ffuncs.add), (table(X, ()), Literal(2)))),
+        bindings={},
+    )
+    assert result.value_numbers[1] != result.value_numbers[2]
+
+
+@pytest.mark.parametrize(
+    "fills",
+    [
+        (DynamicFill(np.float64(1)), DynamicFill(np.float64(2))),
+        (0.0, -0.0),
+    ],
+)
+def test_equal_ftypes_do_not_identify_input_contents_or_fills(fills):
+    a, b = (BufferizedNDArray.from_numpy(np.zeros(3), fill_value=f) for f in fills)
+    result = analyze(
+        Query(X, table(A)), Query(Y, table(B)), bindings={A: ftype(a), B: ftype(b)}
+    )
+    assert result.value_numbers[0] != result.value_numbers[1]
+
+
+def test_unsupported_reduction_and_broadcast_are_opaque(bindings):
+    reduction = Aggregate(Literal(ffuncs.add), Literal(np.int64(0)), table(A), (i,))
+    broadcast = Reorder(table(A), (i, j))
+    for expr in (reduction, broadcast):
+        result = analyze(Query(X, expr), Query(Y, expr), bindings=bindings)
+        assert result.value_numbers[0] != result.value_numbers[1]
+
+
+@pytest.mark.parametrize(
+    "expr,message",
+    [
+        (table(X), "Undefined tensor alias"),
+        (table(A, ()), "Table rank"),
+        (table(A, (i, i)), "fields must be distinct"),
+        (Table(Literal(np.zeros(3)), (i,)), "Extract tensor literals"),
+    ],
+)
+def test_invalid_reads_rejected_before_lhs_definition(bindings, expr, message):
+    with pytest.raises(ValueError, match=message):
+        analyze(Query(X, expr), bindings=bindings)
+
+
+def test_produces_stops_nested_plan(bindings):
+    result = analyze(
+        Plan((Query(X, add()), Produces((X,)))),
+        Query(Y, table(Z)),
+        bindings=bindings,
+    )
+    assert tuple(result.uses) == (0,)
+    with pytest.raises(ValueError, match="Undefined tensor alias"):
+        analyze(Produces((Z,)), bindings=bindings)
+
+
+def test_analysis_does_not_change_ir_or_bindings(bindings):
+    plan = Plan((Query(X, add()), Query(A, add(A, A)), Produces((X,))))
+    original_bindings = bindings.copy()
+    before = repr(plan)
+    result = logic_local_value_numbering(plan, bindings)
+    assert repr(plan) == before
+    assert bindings == original_bindings
+    assert logic_local_value_numbering(plan, bindings) == result
+
+
+def make_tensor(shape, fill_value, *, dtype):
+    # The default interpreter allocator currently drops nonzero fill metadata.
+    return BufferizedNDArray.from_numpy(
+        np.full(shape, fill_value, dtype=dtype(np.int64(0)).dtype),
+        fill_value=fill_value,
+    )
+
+
+def test_copy_and_inplace_semantics_against_interpreter():
+    a = BufferizedNDArray.from_numpy(np.array([1, 2, 3]))
+    b = BufferizedNDArray.from_numpy(np.array([4, 5, 6]))
+    plan = Plan(
+        (
+            Query(X, add()),
+            Query(Y, table(X)),
+            Query(A, add(A, A)),
+            Query(Z, add()),
+            Produces((X, Y, Z)),
+        )
+    )
+    result = logic_local_value_numbering(plan, {A: ftype(a), B: ftype(b)})
+    x, y, z = LogicInterpreter(make_tensor=make_tensor)(plan, {A: a, B: b})
+    np.testing.assert_array_equal(x.to_numpy(), [5, 7, 9])
+    np.testing.assert_array_equal(y.to_numpy(), x.to_numpy())
+    np.testing.assert_array_equal(z.to_numpy(), [6, 9, 12])
+    assert x is not y
+    assert result.value_numbers[0] == result.value_numbers[1]
+    assert result.value_numbers[0] != result.value_numbers[3]
+
+
+def test_external_alias_mutation_against_interpreter():
+    shared = BufferizedNDArray.from_numpy(np.array([1, 2, 3]))
+    plan = Plan(
+        (Query(X, add()), Query(A, add(A, A)), Query(Y, add()), Produces((X, Y)))
+    )
+    result = logic_local_value_numbering(plan, {A: ftype(shared), B: ftype(shared)})
+    x, y = LogicInterpreter(make_tensor=make_tensor)(plan, {A: shared, B: shared})
+    np.testing.assert_array_equal(x.to_numpy(), [2, 4, 6])
+    np.testing.assert_array_equal(y.to_numpy(), [4, 8, 12])
+    assert result.value_numbers[0] != result.value_numbers[2]
+
+
+@pytest.mark.parametrize("source", [np.array([9]), np.array([1.5, 2.5, 3.5])])
+def test_existing_destination_does_not_adopt_rhs_value(source):
+    a = BufferizedNDArray.from_numpy(np.array([1, 2, 3]))
+    b = BufferizedNDArray.from_numpy(source)
+    plan = Plan(
+        (Query(X, table(A)), Query(Y, table(B)), Query(X, table(B)), Produces((X, Y)))
+    )
+    result = logic_local_value_numbering(plan, {A: ftype(a), B: ftype(b)})
+    x, y = LogicInterpreter(make_tensor=make_tensor)(plan, {A: a, B: b})
+    assert result.value_numbers[1] != result.value_numbers[2]
+    assert not np.array_equal(x.to_numpy(), y.to_numpy())
+
+
+def test_external_write_does_not_destroy_local_copy(bindings):
+    result = analyze(
+        Query(X, table(A)), Query(A, table(C)), Query(Y, table(X)), bindings=bindings
+    )
+    assert result.value_numbers[0] == result.value_numbers[2]
+
+
+def test_repeated_computations_after_external_write(bindings):
+    result = analyze(
+        Query(X, add()),
+        Query(A, table(C)),
+        Query(Y, add()),
+        Query(Z, add()),
+        bindings=bindings,
+    )
+    assert result.value_numbers[0] != result.value_numbers[2]
+    assert result.value_numbers[2] == result.value_numbers[3]
+
+
+def test_frontend_generated_elementwise_queries():
+    a = finch.defer(BufferizedNDArray.from_numpy(np.arange(3)))
+    b = finch.defer(BufferizedNDArray.from_numpy(np.arange(3)))
+    x = a + b
+    y = a + b
+    a = a + a
+    z = a + b
+    plan = Plan(
+        x.ctx.join(y.ctx, z.ctx).trace() + (Produces((x.data, y.data, z.data)),)
+    )
+    plan, tensors = extract_tensors(plan, {})
+    result = logic_local_value_numbering(
+        plan, {alias: ftype(tns) for alias, tns in tensors.items()}
+    )
+    vns = {
+        definition.alias: result.value_numbers[sid]
+        for sid, definition in result.definitions.items()
+        if definition.query is not None
+    }
+    assert vns[x.data] == vns[y.data]
+    assert vns[x.data] != vns[z.data]


### PR DESCRIPTION
Track query definitions and equivalent values in sequential Logic plans, with conservative invalidation for tensor writes and unknown effects. Add focused regression and frontend tests. Related to #288; no CSE rewrites or global control-flow analysis yet.